### PR TITLE
Add a title tag to elements in the tree

### DIFF
--- a/src/app/components/model_tree/model_tree_line.html
+++ b/src/app/components/model_tree/model_tree_line.html
@@ -18,7 +18,8 @@
        class='unselectable'
        ng-class="getClass(item)"
        ng-click="activate(item)"
-       data-nav-unique-id="{{ item.unique_id }}">
+       data-nav-unique-id="{{ item.unique_id }}"
+       title="{{ name.name }}">
         <span class="filename">
             <span class="filename-normal">
                 <svg class="icn menu-icon-on"><use xlink:href="{{ getIcon(item.type, 'on') }}"></use></svg>


### PR DESCRIPTION
resolves #202 

### Description

Adds a title attribute to elements in the node list which allows the user to hover / screen read each item in the list.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 