### PR TITLE
Fix non-alphabetical sort of Source Tables in source overview page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## dbt 0.20.1rc1 (Release TBD)
+## dbt-core 1.0.0rc1 (Release TBD)
 
-- Fix docs site crash if `relationships` test has one dependency instead of two ([docs#207](https://github.com/dbt-labs/dbt-docs/issues/207), ([docs#208](https://github.com/dbt-labs/dbt-docs/issues/208)))
 - Fix non-alphabetical sort of Source Tables in source overview page ([docs#81](https://github.com/dbt-labs/dbt-docs/issues/81))
 
 Contributors:
 - [@salmonsd](https://github.com/salmonsd) ([docs#81](https://github.com/dbt-labs/dbt-docs/issues/81))
+
+## dbt 0.20.1rc1 (August 02, 2021)
+
+- Fix docs site crash if `relationships` test has one dependency instead of two ([docs#207](https://github.com/dbt-labs/dbt-docs/issues/207), ([docs#208](https://github.com/dbt-labs/dbt-docs/issues/208)))
 
 ## dbt 0.20.0 (July 12, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## dbt 0.20.1rc1 (Release TBD)
 
 - Fix docs site crash if `relationships` test has one dependency instead of two ([docs#207](https://github.com/dbt-labs/dbt-docs/issues/207), ([docs#208](https://github.com/dbt-labs/dbt-docs/issues/208)))
+- Fix non-alphabetical sort of Source Tables in source overview page ([docs#81](https://github.com/dbt-labs/dbt-docs/issues/81))
+
+Contributors:
+- [@salmonsd](https://github.com/salmonsd) ([docs#81](https://github.com/dbt-labs/dbt-docs/issues/81))
 
 ## dbt 0.20.0 (July 12, 2021
 

--- a/src/app/sources/index.js
+++ b/src/app/sources/index.js
@@ -29,6 +29,9 @@ angular
             if (sources.length == 0) {
                 return;
             }
+            
+            // sort sources by sources.name
+            sources.sort((a,b) => a.name.localeCompare(b.name));
 
             var source = sources[0];
 


### PR DESCRIPTION
resolves #81

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->
When expanding sources, the source list table that's displayed is unsorted.

Fix:
![image](https://user-images.githubusercontent.com/22984014/137528935-f8ac9adf-9ab3-42ab-8162-97a025c2df37.png)


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 