### PR TITLE
Fix bug with missing exposure details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## dbt-core 1.0.0rc1 (Release TBD)
+## dbt-core 1.0.1 (TBD)
+
+- Fix bug with missing exposure details. ([docs#228](https://github.com/dbt-labs/dbt-docs/pull/228))
+
+## dbt-core 1.0.0rc1 (November 10, 2021)
 
 - Fix non-alphabetical sort of Source Tables in source overview page ([docs#81](https://github.com/dbt-labs/dbt-docs/issues/81), [docs#218](https://github.com/dbt-labs/dbt-docs/pull/218))
 - Add title tag to node elements in tree ([docs#202](https://github.com/dbt-labs/dbt-docs/issues/202), [docs#203](https://github.com/dbt-labs/dbt-docs/pull/203))

--- a/src/app/docs/exposure.js
+++ b/src/app/docs/exposure.js
@@ -6,7 +6,7 @@ require("./styles.css");
 
 angular
 .module('dbt')
-.controller('ReportCtrl', ['$scope', '$state', 'project', 'code', '$anchorScroll', '$location',
+.controller('ExposureCtrl', ['$scope', '$state', 'project', 'code', '$anchorScroll', '$location',
             function($scope, $state, projectService, codeService, $anchorScroll, $location) {
 
     $scope.model_uid = $state.params.unique_id;

--- a/src/app/docs/index.js
+++ b/src/app/docs/index.js
@@ -6,5 +6,5 @@ require('./snapshot');
 require('./test');
 require('./macro');
 require('./analysis');
-require('./exposure');
 require('./metric');
+require('./exposure');

--- a/src/app/docs/index.js
+++ b/src/app/docs/index.js
@@ -6,5 +6,5 @@ require('./snapshot');
 require('./test');
 require('./macro');
 require('./analysis');
-require('./metric');
 require('./exposure');
+require('./metric');

--- a/src/app/docs/metric.js
+++ b/src/app/docs/metric.js
@@ -6,7 +6,7 @@ require("./styles.css");
 
 angular
 .module('dbt')
-.controller('ReportCtrl', ['$scope', '$state', 'project', 'code', '$anchorScroll', '$location',
+.controller('MetricCtrl', ['$scope', '$state', 'project', 'code', '$anchorScroll', '$location',
             function($scope, $state, projectService, codeService, $anchorScroll, $location) {
 
     $scope.model_uid = $state.params.unique_id;
@@ -23,6 +23,5 @@ angular
         $scope.parents = dag_utils.getParents(project, metric);
         $scope.parentsLength = $scope.parents.length;
 
-        //$scope.extra_table_fields = []
     })
 }]);

--- a/src/app/index.routes.js
+++ b/src/app/index.routes.js
@@ -118,7 +118,7 @@ angular
         })
         .state('dbt.exposure', {
             url: 'exposure/:unique_id?section&' + graph_params,
-            controller: 'ReportCtrl',
+            controller: 'ExposureCtrl',
             templateUrl: templates.exposure,
             params: {
                 unique_id: {type: 'string'}

--- a/src/app/index.routes.js
+++ b/src/app/index.routes.js
@@ -126,7 +126,7 @@ angular
         })
         .state('dbt.metric', {
             url: 'metric/:unique_id?section&' + graph_params,
-            controller: 'ReportCtrl',
+            controller: 'MetricCtrl',
             templateUrl: templates.metric,
             params: {
                 unique_id: {type: 'string'}


### PR DESCRIPTION
resolves #224 

### Description

Convert to use 2 separate controllers instead of a shared controller for metrics and exposures with multiple definitions.  This allows all fields to show for both kinds of nodes.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 