### PR TITLE
Use column.comment from catalog/database if column.description is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-core 1.1.0 (TBD)
 - Fixed capitalization in UI for exposures of `type: ml` ([#256](https://github.com/dbt-labs/dbt-docs/issues/256))
 - List packages and tags in alphabetical order ([docs#235](https://github.com/dbt-labs/dbt-docs/pull/235))
-- Display column description from database if description is missing from DBT config ([#128](https://github.com/dbt-labs/dbt-docs/issues/128))
+- Display column description from database if description is missing from dbt config ([#128](https://github.com/dbt-labs/dbt-docs/issues/128))
 
 Contributors:
 - [@pgoslatara](https://github.com/pgoslatara) ([docs#235](https://github.com/dbt-labs/dbt-docs/pull/235))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 Contributors:
 - [@pgoslatara](https://github.com/pgoslatara) ([docs#235](https://github.com/dbt-labs/dbt-docs/pull/235))
+- [@halvorlu](https://github.com/halvorlu) ([docs#263](https://github.com/dbt-labs/dbt-docs/pull/263))
 
 ## dbt-core 1.0.4 (March 18th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dbt-core 1.1.0 (TBD)
 - Fixed capitalization in UI for exposures of `type: ml` ([#256](https://github.com/dbt-labs/dbt-docs/issues/256))
 - List packages and tags in alphabetical order ([docs#235](https://github.com/dbt-labs/dbt-docs/pull/235))
+- Display column description from database if description is missing from DBT config ([#128](https://github.com/dbt-labs/dbt-docs/issues/128))
 
 Contributors:
 - [@pgoslatara](https://github.com/pgoslatara) ([docs#235](https://github.com/dbt-labs/dbt-docs/pull/235))

--- a/src/app/components/column_details/column_details.html
+++ b/src/app/components/column_details/column_details.html
@@ -32,7 +32,7 @@
                             <span class='text-dark'>{{ column.type }}</p>
                         </td>
                         <td style="text-overflow: ellipsis; overflow-x: hidden; white-space: nowrap; max-width: 1px;">
-                            <span ng-show="!column.expanded">{{ column.description }}</span>
+                            <span ng-show="!column.expanded">{{ getMergedDescription(column) }}</span>
                         </td>
                         <td>
                             <span class="text-light" ng-show="!column.expanded">
@@ -71,9 +71,9 @@
                                     </div>
                                 </div>
 
-                                <div style="margin-bottom: 15px" ng-if="column.description.length">
+                                <div style="margin-bottom: 15px" ng-if="getMergedDescription(column).length">
                                     <h5>Description</h5>
-                                    <span marked="column.description"></span>
+                                    <span marked="getMergedDescription(column)"></span>
                                 </div>
 
                                 <div ng-show="column.tests && column.tests.length" style="margin-bottom: 15px">

--- a/src/app/components/column_details/column_details.html
+++ b/src/app/components/column_details/column_details.html
@@ -32,7 +32,7 @@
                             <span class='text-dark'>{{ column.type }}</p>
                         </td>
                         <td style="text-overflow: ellipsis; overflow-x: hidden; white-space: nowrap; max-width: 1px;">
-                            <span ng-show="!column.expanded">{{ getMergedDescription(column) }}</span>
+                            <span ng-show="!column.expanded">{{ getDescriptionOrComment(column) }}</span>
                         </td>
                         <td>
                             <span class="text-light" ng-show="!column.expanded">
@@ -71,9 +71,9 @@
                                     </div>
                                 </div>
 
-                                <div style="margin-bottom: 15px" ng-if="getMergedDescription(column).length">
+                                <div style="margin-bottom: 15px" ng-if="getDescriptionOrComment(column).length">
                                     <h5>Description</h5>
-                                    <span marked="getMergedDescription(column)"></span>
+                                    <span marked="getDescriptionOrComment(column)"></span>
                                 </div>
 
                                 <div ng-show="column.tests && column.tests.length" style="margin-bottom: 15px">

--- a/src/app/components/column_details/column_details.js
+++ b/src/app/components/column_details/column_details.js
@@ -21,7 +21,7 @@ angular
 
             scope.has_more_info = function(column) {
                 var tests = (column.tests || []);
-                var description = (column.description || "");
+                var description = scope.getMergedDescription(column);
                 var meta = (column.meta || {});
 
                 return tests.length || description.length || !_.isEmpty(meta);
@@ -35,6 +35,11 @@ angular
 
             scope.getState = function(node) {
                 return 'dbt.' + node.resource_type;
+            }
+
+            scope.getMergedDescription = function(column) {
+                // Prefer description from DBT config if present
+                return column.description || column.comment || "";
             }
 
             scope.get_col_name = function(col_name) {

--- a/src/app/components/column_details/column_details.js
+++ b/src/app/components/column_details/column_details.js
@@ -21,7 +21,7 @@ angular
 
             scope.has_more_info = function(column) {
                 var tests = (column.tests || []);
-                var description = scope.getMergedDescription(column);
+                var description = scope.getDescriptionOrComment(column);
                 var meta = (column.meta || {});
 
                 return tests.length || description.length || !_.isEmpty(meta);
@@ -37,7 +37,7 @@ angular
                 return 'dbt.' + node.resource_type;
             }
 
-            scope.getMergedDescription = function(column) {
+            scope.getDescriptionOrComment = function(column) {
                 // Prefer description from DBT config if present
                 return column.description || column.comment || "";
             }

--- a/src/app/docs/source.html
+++ b/src/app/docs/source.html
@@ -48,8 +48,8 @@
                     <h6>Description</h6>
                     <div class="panel">
                         <div class="panel-body">
-                            <div ng-if="model.description" class="model-markdown" marked="model.description"></div>
-                            <div ng-if="!model.description">This {{ model.resource_type }} is not currently documented</div>
+                            <div ng-if="descriptionOrComment" class="model-markdown" marked="descriptionOrComment"></div>
+                            <div ng-if="!descriptionOrComment">This {{ model.resource_type }} is not currently documented</div>
                         </div>
                     </div>
                 </div>

--- a/src/app/docs/source.js
+++ b/src/app/docs/source.js
@@ -20,6 +20,7 @@ angular
     projectService.ready(function(project) {
         let mod = project.nodes[$scope.model_uid];
         $scope.model = mod;
+        $scope.descriptionOrComment = mod.description || mod.metadata.comment;
         $scope.references = dag_utils.getReferences(project, mod);
         $scope.referencesLength = Object.keys($scope.references).length;
         $scope.parents = dag_utils.getParents(project, mod);


### PR DESCRIPTION
Partially resolves #128 (see below)
### Description

This will display the column description fetched from the database if there is no column description in the DBT config.
Partially resolves #128, partially because the table description is still missing.
Adding the table description would require more substantial changes, since the table description (as far as I could tell) is not found in catalog.json at the moment.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 