### PR TITLE
Updating Jira actions to use project key and version

### DIFF
--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -18,8 +18,10 @@ permissions:
   issues: write
 
 jobs:
-  call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@main
+  jira-issue-creation:
+    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@v1
+    with:
+      project_key: "CT"
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -18,8 +18,10 @@ permissions:
   issues: read
 
 jobs:
-  call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-label.yml@main
+  jira-label:
+    uses: dbt-labs/actions/.github/workflows/jira-label.yml@v1
+    with:
+      project_key: "CT"
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -17,10 +17,12 @@ on:
 
 permissions:
   issues: read
-
+  
 jobs:
-  call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@main
+  jira-transition:
+    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@v1
+    with:
+      project_key: "CT"
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   issues: read
-  
+
 jobs:
   jira-transition:
     uses: dbt-labs/actions/.github/workflows/jira-transition.yml@v1


### PR DESCRIPTION
### Description
Jira mirroring actions in new repo need a project key to be passed. I also am pinning to a major version in case any larger changes need to be made to the action, we can test them out first before bumping up to use it.

* Next steps will be to use these files as a template for all the other repos to move to using

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have generated docs locally, and this change appears to resolve the stated issue
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 