### PR TITLE
[Draft] enable custom node color option in the DAG

### DIFF
--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -191,6 +191,15 @@ angular
                         'background-color': '#ff5688',
                     }
                 },
+                // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
+                // TODO: How to get the custom color from the dictionary mapped below
+                {
+                    selector: 'node[custom_node_color]',
+                    style: {
+                        'background-color': '#cb998f',
+                    }
+    
+                },
                 {
                     selector: 'node[selected=1]',
                     style: {
@@ -216,6 +225,7 @@ angular
                         'background-opacity': 0.5,
                     }
                 },
+
             ],
             ready: function(e) {
                 console.log("graph ready");
@@ -304,6 +314,11 @@ angular
             if (el.data.docs && el.data.docs.show === false) {
                 el.data['hidden'] = 1;
             }
+
+            if (el.data.meta && el.data.meta.node_color) {
+                el.data['custom_node_color'] = el.data.meta.node_color;
+            }
+            
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

Goal is to enable setting customized node colors in a `docs:` block on models. 

```
version: 2
models: 
  - name: model_a
     docs:
       node_color: '#cb998f'
```

Then have a DAG that looks like:

![image](https://user-images.githubusercontent.com/75497565/168450108-83bb21d4-7c5a-48aa-8166-3052e3f3999f.png)

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have generated docs locally, and this change appears to resolve the stated issue
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 