### PR TITLE
Feature: Custom Node Colors for Models

### DIFF
--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -194,9 +194,9 @@ angular
                 // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
                 // TODO: How to get the custom color from the dictionary mapped below
                 {
-                    selector: 'node[custom_node_color]',
+                    selector: 'node[node_color]',
                     style: {
-                        'background-color': '#cb998f',
+                        'background-color': '#e0115f',
                     }
     
                 },
@@ -315,8 +315,13 @@ angular
                 el.data['hidden'] = 1;
             }
 
+            // TODO: This is a hack to get the node to show up in the graph. Remove in preference of the docs config below
             if (el.data.meta && el.data.meta.node_color) {
-                el.data['custom_node_color'] = el.data.meta.node_color;
+                el.data['node_color'] = el.data.meta.node_color;
+            }
+
+            if (el.data.docs && el.data.docs.node_color) {
+                el.data['node_color'] = el.data.docs.node_color;
             }
             
         });

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -192,7 +192,6 @@ angular
                     }
                 },
                 // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
-                // TODO: How to get the custom color from the dictionary mapped below
                 {
                     selector: 'node[node_color]', 
                     style: {
@@ -229,7 +228,6 @@ angular
             ],
             ready: function(e) {
                 console.log("graph ready");
-                console.log("hello YOU" + 'node[node_color]'); // this does NOT show up in the console logs
             },
         }
     }
@@ -316,25 +314,14 @@ angular
             if (el.data.docs && el.data.docs.show === false) {
                 el.data['hidden'] = 1; //set to 1 to set as hidden
             }
-            // TODO: get the hidden nodes to print the color hex and then translate mechanism to node_color
 
-            // TODO: This is a hack to get the node to show up in the graph. Remove in preference of the docs config below
-            if (el.data.meta && el.data.meta.node_color) {
-                el.data['node_color_indicator'] = 1;
-                el.data['node_color'] = el.data.meta.node_color;
-                console.log('hello node_color  ' + el.data['node_color']);
-                console.log('hello node_color_indicator  ' + el.data['node_color_indicator']);
-                // console.log('hello node_color meta  ' + el.data.meta.node_color); redundant, not needed
+            if (el.data.docs && el.data.docs.node_color) {
+                el.data['node_color'] = el.data.docs.node_color;
+                console.log('hello docs node_color  ' + el.data['node_color']);
             }
-
-            // if (el.data.docs && el.data.docs.node_color) {
-            //     el.data['node_color'] = el.data.docs.node_color;
-            // }
             
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});
-        // console.log('hello node_ids  ' + node_ids);
-        console.log('hello elements ' + JSON.stringify(_.each(elements, function(e) { return e.data.node_color}))); //get the node_color isolated in the console logs
         return node_ids;
 
     }

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -78,6 +78,7 @@ angular
             },
             elements: [],
             layout: layouts.none,
+            node_color: '#000000',
             style: [
                 {
                     selector: 'edge.vertical',
@@ -194,9 +195,9 @@ angular
                 // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
                 // TODO: How to get the custom color from the dictionary mapped below
                 {
-                    selector: 'node[node_color]',
+                    selector: 'node[node_color_indicator=1]', //this is correctly mapped to the node_color attribute
                     style: {
-                        'background-color': '#000000',
+                        'background-color': '#000000', //placeholder hex color, this needs to be dynamic
                     }
     
                 },
@@ -229,6 +230,7 @@ angular
             ],
             ready: function(e) {
                 console.log("graph ready");
+                console.log("hello YOU" + 'node[node_color]'); // this does NOT show up in the console logs
             },
         }
     }
@@ -299,7 +301,8 @@ angular
         _.each(service.graph.elements, function(el) {
             el.data['display'] = 'none';
             el.data['selected'] = 0;
-            el.data['hidden'] = 0;
+            el.data['hidden'] = 0; //set to 0 to default to showing
+            el.data['node_color_indicator'] = 0; //If I set a default color, it will override the color set in the service var above and then I have to override the 0 default color again, pretty wasteful
             el.classes = classes;
         });
 
@@ -309,15 +312,21 @@ angular
 
             if (highlight && _.includes(highlight, el.data.unique_id)) {
                 el.data['selected'] = 1;
+                console.log('hello selected node color  ' + el.data['selected']);
             }
 
             if (el.data.docs && el.data.docs.show === false) {
-                el.data['hidden'] = 1;
+                el.data['hidden'] = 1; //set to 1 to set as hidden
             }
+            // TODO: get the hidden nodes to print the color hex and then translate mechanism to node_color
 
             // TODO: This is a hack to get the node to show up in the graph. Remove in preference of the docs config below
             if (el.data.meta && el.data.meta.node_color) {
+                el.data['node_color_indicator'] = 1;
                 el.data['node_color'] = el.data.meta.node_color;
+                console.log('hello node_color  ' + el.data['node_color']);
+                console.log('hello node_color_indicator  ' + el.data['node_color_indicator']);
+                // console.log('hello node_color meta  ' + el.data.meta.node_color); redundant, not needed
             }
 
             // if (el.data.docs && el.data.docs.node_color) {
@@ -326,8 +335,10 @@ angular
             
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});
-
+        // console.log('hello node_ids  ' + node_ids);
+        console.log('hello elements ' + JSON.stringify(_.each(elements, function(e) { return e.data.node_color}))); //get the node_color isolated in the console logs
         return node_ids;
+
     }
 
     service.manifest = {};

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -78,7 +78,6 @@ angular
             },
             elements: [],
             layout: layouts.none,
-            node_color: '#000000',
             style: [
                 {
                     selector: 'edge.vertical',
@@ -195,9 +194,9 @@ angular
                 // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
                 // TODO: How to get the custom color from the dictionary mapped below
                 {
-                    selector: 'node[node_color_indicator=1]', //this is correctly mapped to the node_color attribute
+                    selector: 'node[node_color]', 
                     style: {
-                        'background-color': '#000000', //placeholder hex color, this needs to be dynamic
+                        'background-color': 'data(node_color)', 
                     }
     
                 },
@@ -301,8 +300,7 @@ angular
         _.each(service.graph.elements, function(el) {
             el.data['display'] = 'none';
             el.data['selected'] = 0;
-            el.data['hidden'] = 0; //set to 0 to default to showing
-            el.data['node_color_indicator'] = 0; //If I set a default color, it will override the color set in the service var above and then I have to override the 0 default color again, pretty wasteful
+            el.data['hidden'] = 0;
             el.classes = classes;
         });
 

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -191,7 +191,6 @@ angular
                         'background-color': '#ff5688',
                     }
                 },
-                // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
                 {
                     selector: 'node[node_color]', 
                     style: {
@@ -308,22 +307,19 @@ angular
 
             if (highlight && _.includes(highlight, el.data.unique_id)) {
                 el.data['selected'] = 1;
-                console.log('hello selected node color  ' + el.data['selected']);
             }
 
             if (el.data.docs && el.data.docs.show === false) {
-                el.data['hidden'] = 1; //set to 1 to set as hidden
+                el.data['hidden'] = 1;
             }
 
             if (el.data.docs && el.data.docs.node_color) {
                 el.data['node_color'] = el.data.docs.node_color;
-                console.log('hello docs node_color  ' + el.data['node_color']);
             }
             
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});
         return node_ids;
-
     }
 
     service.manifest = {};

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -191,6 +191,15 @@ angular
                         'background-color': '#ff5688',
                     }
                 },
+                // apply custom colors on top of all defaults, but allow the selected and hidden options below to override this
+                // TODO: How to get the custom color from the dictionary mapped below
+                {
+                    selector: 'node[custom_node_color]',
+                    style: {
+                        'background-color': '#cb998f',
+                    }
+    
+                },
                 {
                     selector: 'node[selected=1]',
                     style: {
@@ -216,6 +225,7 @@ angular
                         'background-opacity': 0.5,
                     }
                 },
+
             ],
             ready: function(e) {
                 console.log("graph ready");
@@ -304,6 +314,11 @@ angular
             if (el.data.docs && el.data.docs.show === false) {
                 el.data['hidden'] = 1;
             }
+
+            if (el.data.meta && el.data.meta.node_color) {
+                el.data['custom_node_color'] = el.data.meta.node_color;
+            }
+            
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});
 

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -196,7 +196,7 @@ angular
                 {
                     selector: 'node[node_color]',
                     style: {
-                        'background-color': '#e0115f',
+                        'background-color': '#000000',
                     }
     
                 },
@@ -320,9 +320,9 @@ angular
                 el.data['node_color'] = el.data.meta.node_color;
             }
 
-            if (el.data.docs && el.data.docs.node_color) {
-                el.data['node_color'] = el.data.docs.node_color;
-            }
+            // if (el.data.docs && el.data.docs.node_color) {
+            //     el.data['node_color'] = el.data.docs.node_color;
+            // }
             
         });
         service.graph.elements = _.filter(elements, function(e) { return e.data.display == 'element'});

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -196,7 +196,6 @@ angular
                     style: {
                         'background-color': 'data(node_color)', 
                     }
-    
                 },
                 {
                     selector: 'node[selected=1]',
@@ -223,7 +222,6 @@ angular
                         'background-opacity': 0.5,
                     }
                 },
-
             ],
             ready: function(e) {
                 console.log("graph ready");


### PR DESCRIPTION
resolves #44

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->

When looking at a DAG, there are a couple of visually oriented questions that immediately come to mind:
- Can I understand the flow at a higher level than the individual nodes?
- E.g. “layers”, or bronze/silver/gold etc.
- The above shows a trend in which dbt is being asked to manage more types of objects than tables and views at a surface level. That being the case, it makes sense to make it easier to reason about those various DAG components more flexibly than we do today.

I'm able to get the node custom color dynamically mapped to the right nodes and with dynamic colors to boot! Similar to what's accomplished in #275 

 - [ ] This code will only work once this PR is merged: https://github.com/dbt-labs/dbt-core/pull/5343

Notion link for my scratchpad troubleshooting: [here](https://www.notion.so/dbtlabs/Update-Custom-Coloring-Logic-8ddfff8355fa400daa367d7370e79ad7)

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/19176976/173416297-75fe1bf5-e80e-4f47-98e3-84f8d334fdce.png">


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 