### PR TITLE
Improve metrics docs & DAG viz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [Snyk] Upgrade prismjs from 1.27.0 to 1.28.0 ([#271](https://github.com/dbt-labs/dbt-docs/issues/271))
 - Fixed sample SQL Code for sources when no database is defined ([docs#272](https://github.com/dbt-labs/dbt-docs/pull/272))
 - Run build and tests in CI checks ([docs#274](https://github.com/dbt-labs/dbt-docs/pull/274))
+- Improve metrics DAG viz and documentation page ([docs#285](https://github.com/dbt-labs/dbt-docs/pull/285))
 
 Contributors:
 - [@b-per](https://github.com/b-per) ([docs#272](https://github.com/dbt-labs/dbt-docs/pull/272))

--- a/src/app/components/search/search.js
+++ b/src/app/components/search/search.js
@@ -64,11 +64,11 @@ angular
                 _.each(results, function(result){
                     _.each(result.matches, function(match){
                        if(!fileIDs.includes(result.model['unique_id'])){
-                           let nameMatch = show_names && (match.key === "name" || match.key == 'label');
-                           let descriptionMatch = show_descriptions && match.key == "description";
-                           let columnsMatch = show_columns && match.key === "columns";
-                           let codeMatch = show_code && match.key === "raw_sql";
-                           let tagsMatch = show_tags && match.key === "tags";
+                           const nameMatch = show_names && (match.key === "name" || match.key == 'label');
+                           const descriptionMatch = show_descriptions && match.key == "description";
+                           const columnsMatch = show_columns && match.key === "columns";
+                           const codeMatch = show_code && match.key === "raw_sql";
+                           const tagsMatch = show_tags && match.key === "tags";
 
                            if(nameMatch || descriptionMatch || columnsMatch || codeMatch || tagsMatch) {
                             fileIDs.push(result.model['unique_id']);

--- a/src/app/components/search/search.js
+++ b/src/app/components/search/search.js
@@ -45,6 +45,8 @@ angular
                     return model.source_name + "." + model.name;
                 } else if (model.resource_type == 'macro') {
                     return model.package_name + "." + model.name;
+                } else if (model.resource_type == 'metric') {
+                    return model.label;
                 } else {
                     return model.name;
                 }
@@ -62,7 +64,13 @@ angular
                 _.each(results, function(result){
                     _.each(result.matches, function(match){
                        if(!fileIDs.includes(result.model['unique_id'])){
-                           if((show_names && match.key === "name") || (show_descriptions && match.key === "description") || (show_columns && match.key === "columns") || (show_code && match.key === "raw_sql") || (show_tags && match.key === "tags")){
+                           let nameMatch = show_names && (match.key === "name" || match.key == 'label');
+                           let descriptionMatch = show_descriptions && match.key == "description";
+                           let columnsMatch = show_columns && match.key === "columns";
+                           let codeMatch = show_code && match.key === "raw_sql";
+                           let tagsMatch = show_tags && match.key === "tags";
+
+                           if(nameMatch || descriptionMatch || columnsMatch || codeMatch || tagsMatch) {
                             fileIDs.push(result.model['unique_id']);
                             finalResults.push(result);
                            }

--- a/src/app/docs/metric.html
+++ b/src/app/docs/metric.html
@@ -21,7 +21,7 @@
             <div class="app-frame app-pad app-flush-bottom">
 
                 <h1>
-                    <span class="break">{{ metric.name }}</span>
+                    <span class="break">{{ metric.label }}</span>
                     <small>metric</small>
 
                     <div class='clearfix'></div>

--- a/src/app/docs/metric.html
+++ b/src/app/docs/metric.html
@@ -34,6 +34,7 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.metric({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
     </div>
@@ -66,6 +67,13 @@
                 </div>
             </section>
 
+
+            <section class="section">
+                <div class="section-target" id="code"></div>
+                <div class="section-content">
+                    <code-block versions="versions" default="default_version"></code-block>
+                </div>
+            </section>
         </div>
     </div>
 </div>

--- a/src/app/docs/metric.js
+++ b/src/app/docs/metric.js
@@ -23,5 +23,23 @@ angular
         $scope.parents = dag_utils.getParents(project, metric);
         $scope.parentsLength = $scope.parents.length;
 
+        $scope.versions = {
+            'Definition': codeService.generateMetricSQL($scope.metric)
+        }
+
+        let metric_type;
+        if ($scope.metric.type == 'expression') {
+            metric_type = 'Expression metric';
+        } else {
+            metric_type = 'Aggregate metric';
+        }
+
+        $scope.extra_table_fields = [
+            {
+                name: "Metric Type",
+                value: metric_type,
+            },
+        ]
+
     })
 }]);

--- a/src/app/docs/metric.js
+++ b/src/app/docs/metric.js
@@ -39,6 +39,10 @@ angular
                 name: "Metric Type",
                 value: metric_type,
             },
+            {
+                name: "Metric name",
+                value: $scope.metric.name
+            }
         ]
 
     })

--- a/src/app/docs/metric.js
+++ b/src/app/docs/metric.js
@@ -27,12 +27,9 @@ angular
             'Definition': codeService.generateMetricSQL($scope.metric)
         }
 
-        let metric_type;
-        if ($scope.metric.type == 'expression') {
-            metric_type = 'Expression metric';
-        } else {
-            metric_type = 'Aggregate metric';
-        }
+        const metric_type =  $scope.metric.type === 'expression'
+            ? 'Expression metric'
+            : 'Aggregate metric';
 
         $scope.extra_table_fields = [
             {

--- a/src/app/services/code_service.js
+++ b/src/app/services/code_service.js
@@ -56,6 +56,29 @@ angular
         return query.join("\n");
     }
 
+    service.generateMetricSQL = function(metric) {
+        if (metric.type == 'expression') {
+            return metric.sql
+        } else {
+            // TODO: include filters!
+            let query_parts = [
+                `select ${metric.type}(${metric.sql})` ,
+                `from {{ ${metric.model} }}`,
+            ]
+
+            if (metric.filters.length > 0) {
+                let filter_exprs = _.map(metric.filters, (filter) => {
+                    return `${filter.field} ${filter.operator} ${filter.value}`
+                })
+
+                let filters = filter_exprs.join(" AND ")
+                query_parts.push(`where ${filters}`)
+            }
+
+            return query_parts.join("\n")
+        }
+    }
+
     return service;
 
 }]);

--- a/src/app/services/code_service.js
+++ b/src/app/services/code_service.js
@@ -58,24 +58,24 @@ angular
 
     service.generateMetricSQL = function(metric) {
         if (metric.type == 'expression') {
-            return metric.sql
-        } else {
-            let query_parts = [
-                `select ${metric.type}(${metric.sql})` ,
-                `from {{ ${metric.model} }}`,
-            ]
-
-            if (metric.filters.length > 0) {
-                let filter_exprs = _.map(metric.filters, (filter) => {
-                    return `${filter.field} ${filter.operator} ${filter.value}`
-                })
-
-                let filters = filter_exprs.join(" AND ")
-                query_parts.push(`where ${filters}`)
-            }
-
-            return query_parts.join("\n")
+            return metric.sql;
         }
+
+        const queryParts = [
+            `select ${metric.type}(${metric.sql})` ,
+            `from {{ ${metric.model} }}`,
+        ];
+
+        if (metric.filters.length > 0) {
+            const filterExprs = metric.filters.map(filter => (
+                `${filter.field} ${filter.operator} ${filter.value}`
+            ));
+
+            const filters = filterExprs.join(' AND ');
+            queryParts.push(`where ${filters}`);
+        }
+
+        return queryParts.join('\n');
     }
 
     return service;

--- a/src/app/services/code_service.js
+++ b/src/app/services/code_service.js
@@ -60,7 +60,6 @@ angular
         if (metric.type == 'expression') {
             return metric.sql
         } else {
-            // TODO: include filters!
             let query_parts = [
                 `select ${metric.type}(${metric.sql})` ,
                 `from {{ ${metric.model} }}`,

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -357,7 +357,7 @@ angular
                 var parent_node = service.manifest.nodes[parent];
                 var child_node = service.manifest.nodes[child];
 
-                if (!_.includes(['model', 'source', 'seed', 'snapshot'], parent_node.resource_type)) {
+                if (!_.includes(['model', 'source', 'seed', 'snapshot', 'metric'], parent_node.resource_type)) {
                     return;
                 } else if (child_node.resource_type == 'test' && child_node.hasOwnProperty('test_metadata')) {
                     return;

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -131,6 +131,7 @@ angular
 
             // Set node labels
             _.each(service.files.manifest.nodes, function(node) {
+                // use existing label if defined in manifest (eg. for metrics)
                 node.label = node.name;
             });
 
@@ -148,7 +149,6 @@ angular
             
             // Add metrics back into nodes to make site logic work
             _.each(service.files.manifest.metrics, function(node) {
-                node.label = node.name;
                 service.files.manifest.nodes[node.unique_id] = node;
             });
 
@@ -264,6 +264,7 @@ angular
             'columns':'object',
             'tags': 'array',
             'arguments': 'array',
+            'label': 'string',
         };
         var search = new RegExp(val, "i")
 
@@ -523,7 +524,7 @@ angular
 
             metrics[project].items.push({
                 type: 'file',
-                name: name,
+                name: node.label,
                 node: node,
                 active: is_active,
                 unique_id: node.unique_id,

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -131,7 +131,6 @@ angular
 
             // Set node labels
             _.each(service.files.manifest.nodes, function(node) {
-                // use existing label if defined in manifest (eg. for metrics)
                 node.label = node.name;
             });
 


### PR DESCRIPTION
resolves #246 

### Description

This PR:
- Draws DAG edges for expression metrics (ie. a metric that depends on one or more other metrics)
- Renders labels, types (expression vs. aggregate), and SQL for each metric
- Uses the metric label rather than the name in the sidebar + DAG viz + search results
- Supports search results on metric + label name (eg. both "arpc" and "Revenue") should pull up the arpc metric


**Screenshots**

_Expression metrics render in the DAG view_
<img width="1411" alt="Screen Shot 2022-06-30 at 4 27 54 PM" src="https://user-images.githubusercontent.com/1541139/176772698-a1fa76db-b114-4b1f-b8e2-7cf20a97c8bb.png">

_Render the name, label, and type for each metric_
<img width="1552" alt="Screen Shot 2022-06-30 at 4 28 25 PM" src="https://user-images.githubusercontent.com/1541139/176772699-94beba1c-9dec-463e-bc5c-9c7d7bc0fad9.png">


**Example metric SQL definition:**
```
select sum(order_total)
from {{ ref('fct_orders') }}
where is_paid = true
```


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 