### PR TITLE
[Bug] Generate Updated Docs for dbt-core fails to delete changie files

### DIFF
--- a/.github/workflows/generate-docs-for-dbt-core.yml
+++ b/.github/workflows/generate-docs-for-dbt-core.yml
@@ -190,7 +190,7 @@ jobs:
         id: changie_check
         run: |
           if [[ -z $(find ./.changes/unreleased -type f -name "*.yaml") ]]; then
-            echo No changie yaml files to delete.  This is unexpected.
+            echo "No changie yaml files to delete.  This is unexpected."
             exit 1
           fi
 

--- a/.github/workflows/generate-docs-for-dbt-core.yml
+++ b/.github/workflows/generate-docs-for-dbt-core.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Check for changed changie yaml files
         id: changie_check
         run: |
-          if [[ -z $(find ./.changes/unreleased -type f -name "*.yaml") ]] then
+          if [[ -z $(find ./.changes/unreleased -type f -name "*.yaml") ]]; then
             echo No changie yaml files to delete.  This is unexpected.
             exit 1
           fi

--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -8,7 +8,7 @@
 # This will run when called in manually or as part of the workflow to generate a new index file for release.
 
 
-name: Generate Updated Docs for dbt-core
+name: Generate Index file for testing
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
No issue

### Description

The GHA `generate-docs-for-dbt-core.yml` was missing a semicolon and failed to remove changelog files from `dbt-docs` repo once everything was successfully moved over to `dbt-core`.

Also give `generate-index.yml` a unique name.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 