### PR TITLE
add new line for single command in GHA

### DIFF
--- a/.github/workflows/generate-docs-for-dbt-core.yml
+++ b/.github/workflows/generate-docs-for-dbt-core.yml
@@ -40,7 +40,7 @@ jobs:
           echo "::set-output name=INDEX_ARTIFACT_NAME::index_file"
           echo "::set-output name=CHANGIE_ARTIFACT_NAME::changie_yamls"
           echo "::set-output name=PR_TITLE::Add most recent dbt-docs changes"
-          echo "::set-output name=PR_BODY::Auto generated changes from `generate-docs-for-dbt-core.yml` workflow"
+          echo "::set-output name=PR_BODY::Auto generated changes from generate-docs-for-dbt-core.yml workflow"
 
       - name: Print variables
         id: print_variables
@@ -222,7 +222,7 @@ jobs:
           gh pr create --title "Remove moved changie yml files" \
                        --body "${{ needs.set_variables.outputs.pr_body }}" \
                        --base main \
-                       --head ${{ needs.set_variables.outputs.branch_name }}
+                       --head ${{ needs.set_variables.outputs.branch_name }} \
                        --label "Skip Changelog"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
resolves None

### Description

I honestly have no idea what happened.  This was tested and working and somehow a few syntax errors made it in that would cause the last job to always fail.  I looked at the history and can't figure it out.  This should resolve.

This fixes the last PR creation to remove the changelog yaml files by adding the Skip Changelog label correctly within the `gh pr create...` command.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 