### PR TITLE
add selector for python models

### DIFF
--- a/.changes/unreleased/Docs-20221017-171411.yaml
+++ b/.changes/unreleased/Docs-20221017-171411.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+time: 2022-10-17T17:14:11.715348-05:00
+custom:
+  Author: paulbenschmidt
+  Issue: "5880"
+  PR: "324"

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -193,9 +193,15 @@ angular
                     }
                 },
                 {
-                    selector: 'node[node_color]', 
+                    selector: 'node[language="python"]',
                     style: {
-                        'background-color': 'data(node_color)', 
+                        'background-color': '#e3ad06',
+                    }
+                },
+                {
+                    selector: 'node[node_color]',
+                    style: {
+                        'background-color': 'data(node_color)',
                     }
                 },
                 {

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -195,7 +195,7 @@ angular
                 {
                     selector: 'node[language="python"]',
                     style: {
-                        'background-color': '#e3ad06',
+                        'background-color': '#6a5acd',
                     }
                 },
                 {


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/5880

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Changes default color assignment of Python models in lineage graph so that they're easily distinguishable from SQL models. After scanning the current colors, I figured that some type of yellow would be the safest bet; I'm including a few variations below...

#e3ad06 (proposed) - it looks a little like mustard, but I wanted it to be dark enough for the characters to contrast
<img width="1391" alt="Screen Shot 2022-10-17 at 4 59 18 PM" src="https://user-images.githubusercontent.com/47193122/196291792-385e9f17-2043-46c7-9e52-bca7b14e74d0.png">


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 