### PR TITLE
point at main

### DIFF
--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -18,8 +18,8 @@ permissions:
   issues: write
 
 jobs:
-  jira-issue-creation:
-    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@v1
+  call-creation-action:
+    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@main
     with:
       project_key: "CT"
     secrets:

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -18,8 +18,8 @@ permissions:
   issues: read
 
 jobs:
-  jira-label:
-    uses: dbt-labs/actions/.github/workflows/jira-label.yml@v1
+  call-label-action:
+    uses: dbt-labs/actions/.github/workflows/jira-label.yml@main
     with:
       project_key: "CT"
     secrets:

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -15,12 +15,12 @@ on:
   issues:
     types: [closed, deleted, reopened]
 
-permissions:
-  issues: read
+# no special access is needed
+permissions: read-all
 
 jobs:
-  jira-transition:
-    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@v1
+  call-transition-action:
+    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@main
     with:
       project_key: "CT"
     secrets:


### PR DESCRIPTION
Points the jira actions to main instead of a tag.  It was decided to not point to tags to prevent confusion as to what updates every shared workflow has.
 