### PR TITLE
View documentation in new tab

### DIFF
--- a/.changes/unreleased/Docs-20221120-150014.yaml
+++ b/.changes/unreleased/Docs-20221120-150014.yaml
@@ -1,0 +1,7 @@
+kind: Docs
+body: Adds "View documentation in new tab" option in the DAG view
+time: 2022-11-20T15:00:14.068702-07:00
+custom:
+  Author: datadisciple
+  Issue: "348"
+  PR: "349"

--- a/src/app/components/graph/graph-viz.js
+++ b/src/app/components/graph/graph-viz.js
@@ -167,6 +167,19 @@ angular
                     show: true,
                 },
                 {
+                    id: 'docs-new-tab',
+                    content: 'View documentation in new tab',
+                    selector: 'node',
+                    tooltipText: 'Open the documentation for this node in a new browser tab',
+                    onClickFunction: function(event) {
+                        var target = event.target || event.cyTarget
+                        var unique_id = target.id();
+                        var url = $state.href('dbt.' + target.data('resource_type'), {unique_id: unique_id}, {absolute: true, inherit: false});
+                        window.open(url, '_blank');
+                    },
+                    show: true,
+                },
+                {
                     id: 'hide-before-here',
                     content: 'Hide this and parents',
                     selector: 'node',


### PR DESCRIPTION
resolves #348 

### Description
Adds a new right-click menu item to the DAG view &rarr; "View documentation in new tab"

<img width="544" alt="Screen Shot 2022-11-20 at 2 43 58 PM" src="https://user-images.githubusercontent.com/52979190/202928027-287a749f-9d81-49ab-9805-4c79f2f98d94.png">

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 