### PR TITLE
Improve displayed message under "Arguments" section for argumentless macro

### DIFF
--- a/.changes/unreleased/Docs-20230113-094855.yaml
+++ b/.changes/unreleased/Docs-20230113-094855.yaml
@@ -1,0 +1,7 @@
+kind: Docs
+body: Improve displayed message under "Arguments" section for argumentless macro
+time: 2023-01-13T09:48:55.574898-05:00
+custom:
+  Author: MartinGuindon
+  Issue: "358"
+  PR: "359"

--- a/src/app/components/macro_arguments/index.html
+++ b/src/app/components/macro_arguments/index.html
@@ -12,7 +12,7 @@
     <div class="panel-body">
         <div ng-if="macro.arguments.length == 0">
             Details are not available for this macro. This may be due to the fact that this macro doesn't have any
-            argument or that they haven't been documented yet.
+            arguments or that they haven't been documented yet.
         </div>
         <div ng-if="macro.arguments.length > 0" class="table-responsive" style="max-height: 800px; overflow-y: scroll;">
             <table class="table table-borderless table-hover">

--- a/src/app/components/macro_arguments/index.html
+++ b/src/app/components/macro_arguments/index.html
@@ -1,22 +1,20 @@
 <style>
-.arg-header {
-    background-color: white;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-}
+    .arg-header {
+        background-color: white;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
 
 </style>
 
 <div class="panel">
     <div class="panel-body">
         <div ng-if="macro.arguments.length == 0">
-            Details are not available for this macro
+            Details are not available for this macro. This may be due to the fact that this macro doesn't have any
+            argument or that they haven't been documented yet.
         </div>
-        <div
-            ng-if="macro.arguments.length > 0"
-            class="table-responsive"
-            style="max-height: 800px; overflow-y: scroll;">
+        <div ng-if="macro.arguments.length > 0" class="table-responsive" style="max-height: 800px; overflow-y: scroll;">
             <table class="table table-borderless table-hover">
                 <thead>
                     <tr>
@@ -27,11 +25,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat-start="arg in macro.arguments"
-                        ng-click="arg.expanded = !arg.expanded"
+                    <tr ng-repeat-start="arg in macro.arguments" ng-click="arg.expanded = !arg.expanded"
                         ng-class="{'column-row-selected': arg.expanded}"
-                        ng-style="{cursor: arg.description ? 'pointer' : 'auto'}"
-                        class="column-row">
+                        ng-style="{cursor: arg.description ? 'pointer' : 'auto'}" class="column-row">
                         <td>
                             <div>
                                 <span class='text-dark'>{{ arg.name }}</span>
@@ -46,17 +42,19 @@
                         <td class='text-center'>
                             <span class='text-light' ng-show="arg.description">
                                 <span ng-if="arg.expanded">
-                                    <svg class="icn"><use xlink:href="#icn-up"></use></svg>
+                                    <svg class="icn">
+                                        <use xlink:href="#icn-up"></use>
+                                    </svg>
                                 </span>
                                 <span ng-if="!arg.expanded">
-                                    <svg class="icn"><use xlink:href="#icn-right"></use></svg>
+                                    <svg class="icn">
+                                        <use xlink:href="#icn-right"></use>
+                                    </svg>
                                 </span>
                             </span>
                         </td>
                     </tr>
-                    <tr ng-repeat-end
-                        ng-show="arg.expanded"
-                        style="background-color: white; padding: 10px">
+                    <tr ng-repeat-end ng-show="arg.expanded" style="background-color: white; padding: 10px">
                         <td colspan="4" class="column-expanded">
                             <div style="padding: 5px 20px">
                                 <div style="margin-bottom: 15px">


### PR DESCRIPTION
resolves #358 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

This PR changes the message displayed when no arguments are documented for the macro, as discussed in #358.

<img width="1482" alt="Screenshot 2023-01-13 at 9 23 21 AM" src="https://user-images.githubusercontent.com/14781590/212348055-9cfe41c3-7d04-4f02-aae6-1297004eec5c.png">



### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 