### PR TITLE
Fix JSON path to overview docs

### DIFF
--- a/.changes/unreleased/Docs-20230209-082901.yaml
+++ b/.changes/unreleased/Docs-20230209-082901.yaml
@@ -1,0 +1,7 @@
+kind: Docs
+body: Fix JSON path to overview docs
+time: 2023-02-09T08:29:01.432616-07:00
+custom:
+  Author: halvorlu
+  Issue: "366"
+  PR: "367"

--- a/src/app/overview/index.js
+++ b/src/app/overview/index.js
@@ -15,7 +15,7 @@ angular
                 : null;
             
             // default;
-            var selected_overview = project.docs["dbt.__overview__"];
+            var selected_overview = project.docs["doc.dbt.__overview__"];
             var overviews = _.filter(project.docs, {name: '__overview__'});
             _.each(overviews, function (overview) {
                 if (overview.package_name != 'dbt') {


### PR DESCRIPTION
Resolves #366

### Description
A minor change to correct the path to the overview markdown in `manifest.json`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 