### PR TITLE
Add model owner from group, standardize exposure owner

### DIFF
--- a/.changes/unreleased/Docs-20230227-141424.yaml
+++ b/.changes/unreleased/Docs-20230227-141424.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Display model owner by name and email
+time: 2023-02-27T14:14:24.630816-06:00
+custom:
+  Author: emmyoop
+  Issue: "377"

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -107,12 +107,9 @@ angular
                     relation = database + model.schema + "." + model.alias;
                 }
 
-                var owner_identifier
-                if (model.group) {
-                    owner_identifier = retrieveOwner(`group.${model.package_name}.${model.group}`)
-                } else {
-                    owner_identifier = metadata.owner
-                }
+                const owner_identifier = model.group
+                    ? retrieveOwner(`group.${model.package_name}.${model.group}`)
+                    : metadata.owner;
 
                 var stats = [
                     {

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -75,17 +75,16 @@ angular
             }
 
             function retrieveOwner(group) {
-                var owner = project.project.groups[group].owner
-                var owner_identifier
-                if (owner.name && owner.email) {
-                    owner_identifier = `${owner.name} <${owner.email}>`
-                  } else if (model.owner.name) {
-                    owner_identifier = `${owner.name}`
-                  } else if (owner.email) {
-                    owner_identifier = `${owner.email}`
-                  }
-                
-                return owner_identifier
+                const {name, email} = project.project.groups[group].owner;
+                const result = [];
+                if (name) result.push(name);
+                if (email) {
+                    const toPush = result.length > 0
+                        ? `<${email}>`
+                        : email;
+                    result.push(toPush);
+                }
+                return result.join(" ");
             }
 
             function getBaseStats(model) {

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -7,7 +7,7 @@ const _ = require('underscore');
 
 angular
 .module('dbt')
-.directive('tableDetails', ["$sce", "$filter", function($sce, $filter) {
+.directive('tableDetails', ["$sce", "$filter", "project" ,function($sce, $filter, project) {
     return {
         scope: {
             model: '=',
@@ -74,6 +74,20 @@ angular
                 }
             }
 
+            function retrieveOwner(group) {
+                var owner = project.project.groups[group].owner
+                var owner_identifier
+                if (owner.name && owner.email) {
+                    owner_identifier = `${owner.name} <${owner.email}>`
+                  } else if (model.owner.name) {
+                    owner_identifier = `${owner.name}`
+                  } else if (owner.email) {
+                    owner_identifier = `${owner.email}`
+                  }
+                
+                return owner_identifier
+            }
+
             function getBaseStats(model) {
                 var is_ephemeral = !model.metadata;
                 var metadata = model.metadata || {};
@@ -94,10 +108,17 @@ angular
                     relation = database + model.schema + "." + model.alias;
                 }
 
+                var owner_identifier
+                if (model.group) {
+                    owner_identifier = retrieveOwner(`group.${model.package_name}.${model.group}`)
+                } else {
+                    owner_identifier = metadata.owner
+                }
+
                 var stats = [
                     {
                         name: "Owner",
-                        value: metadata.owner
+                        value: owner_identifier
                     },
                     {
                         name: "Type",

--- a/src/app/docs/exposure.js
+++ b/src/app/docs/exposure.js
@@ -24,6 +24,15 @@ angular
         $scope.parentsLength = $scope.parents.length;
         $scope.language = exposure.language;
 
+        var owner_identifier
+        if ($scope.exposure.owner.name && $scope.exposure.owner.email) {
+            owner_identifier = `${$scope.exposure.owner.name} <${$scope.exposure.owner.email}>`
+          } else if ($scope.exposure.owner.name) {
+            owner_identifier = `${$scope.exposure.owner.name}`
+          } else if ($scope.exposure.owner.email) {
+            owner_identifier = `${$scope.exposure.owner.email}`
+          }
+        
         $scope.extra_table_fields = [
             {
                 name: "Maturity",
@@ -31,11 +40,7 @@ angular
             },
             {
                 name: "Owner",
-                value: $scope.exposure.owner.name,
-            },
-            {
-                name: "Owner email",
-                value: $scope.exposure.owner.email,
+                value: owner_identifier
             },
             {
                 name: "Exposure name",


### PR DESCRIPTION
resolves #377 

### Description

Updates Exposure owner to be more like git owner in the format `name<email>` when both fields are available, otherwise it shows just the available field.

Also adds this functionality to models with group owners.  If the model is not part of a group, it continues to show the owner from the warehouse as it currently shows.

model in a group
![Screen Shot 2023-02-27 at 2 12 12 PM](https://user-images.githubusercontent.com/7070049/221674030-1cc1a70a-842c-4c5d-a814-9ca5ea361f34.png)

model _not_ in a group
![Screen Shot 2023-02-27 at 2 12 17 PM](https://user-images.githubusercontent.com/7070049/221674035-2ed86740-521b-417d-b6d4-a9b5e0ee881e.png)

exposure with blank owner name
![Screen Shot 2023-02-27 at 2 12 26 PM](https://user-images.githubusercontent.com/7070049/221674039-677d03ba-cb14-4eef-8923-3afabe817fb6.png)

exposure with blank owner email
![Screen Shot 2023-02-27 at 2 12 30 PM](https://user-images.githubusercontent.com/7070049/221674046-90dd85ae-f244-4a58-9425-44fd4b32d866.png)

exposure with name and email filled
![Screen Shot 2023-02-27 at 2 12 35 PM](https://user-images.githubusercontent.com/7070049/221674050-e3af7c65-08bb-4a42-8e2c-71ecd5f9f833.png)


### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 