### PR TITLE
revert from #376

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ env/
 .tmp/
 dist/
 .sass-cache/
+package-lock.json
 env*

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 ruby 2.7.5
-nodejs 16.13.1
+nodejs 14.18.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -18017,7 +18017,6 @@
     },
     "cytoscape": {
       "version": "git+ssh://git@github.com/dbt-labs/cytoscape.js.git#b8a1192c270de70296a0381bd0bfe26a5ddeada3",
-      "integrity": "sha512-CJDw3nomL5E4OgviTrBhkfLCVaA5bDS5BTuLKY0Qk+/AK75Quue/e5z68RCpwe2G7XMoPjosP0xOrAje2dn6HQ==",
       "dev": true,
       "from": "cytoscape@https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
       "requires": {


### PR DESCRIPTION
This line broke our automated index generation for dbt-core.  Reverting to previous state.  Also updates project to meet expected versions.

Should we ignore the packagelock always?

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 