### PR TITLE
change node shape based on access type.

### DIFF
--- a/.changes/unreleased/Docs-20230307-104219.yaml
+++ b/.changes/unreleased/Docs-20230307-104219.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Distiguish access type in the DAG with node shape.
+time: 2023-03-07T10:42:19.044231-06:00
+custom:
+  Author: emmyoop
+  Issue: "378"

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -229,6 +229,18 @@ angular
                         'background-opacity': 0.5,
                     }
                 },
+                {
+                    selector: 'node[access="private"]',
+                    style: {
+                        'shape': 'rectangle',
+                    }
+                },
+                {
+                    selector: 'node[access="public"]',
+                    style: {
+                        'shape': 'ellipse',
+                    }
+                },
             ],
             ready: function(e) {
                 console.log("graph ready");


### PR DESCRIPTION
resolves #378 

### Description
Here's what I came up with with the help of @dbeatty10 

`access: protected` - nothing custom - stays the rounded corner rectangle.  This allows the DAG to visually remain exactly the same until groups/access are added to a project
`access: public` - ellipse shape - This really distinguishes the public nodes that will be accessible outside the project
`access: private` - sharp cornered rectangle

|node|access|
| ----------- | ----------- |
|`raw_people_list`|no access defined explicitly|
|`second-model-private`|`access: private`|
|`second-model-public`|`access: public`|
|`top-model` |`access: protected`|

![Screen Shot 2023-03-07 at 10 49 52 AM](https://user-images.githubusercontent.com/7070049/223491521-9fa0a98d-073f-457d-8273-bc75f151991a.png)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 