### PR TITLE
Fix JSON path to package overview docs

### DIFF
--- a/.changes/unreleased/Docs-20230307-174951.yaml
+++ b/.changes/unreleased/Docs-20230307-174951.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Fix JSON path to package overview docs
+time: 2023-03-07T17:49:51.256097-07:00
+custom:
+  Author: rlh1994 dbeatty10
+  Issue: "390"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18017,6 +18017,7 @@
     },
     "cytoscape": {
       "version": "git+ssh://git@github.com/dbt-labs/cytoscape.js.git#b8a1192c270de70296a0381bd0bfe26a5ddeada3",
+      "integrity": "sha512-CJDw3nomL5E4OgviTrBhkfLCVaA5bDS5BTuLKY0Qk+/AK75Quue/e5z68RCpwe2G7XMoPjosP0xOrAje2dn6HQ==",
       "dev": true,
       "from": "cytoscape@https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
       "requires": {

--- a/src/app/overview/index.js
+++ b/src/app/overview/index.js
@@ -24,7 +24,7 @@ angular
             });
             // Select project-level overviews
             if (project_name !== null) {
-                selected_overview = project.docs[`${project_name}.__${project_name}__`] || selected_overview
+                selected_overview = project.docs[`doc.${project_name}.__${project_name}__`] || selected_overview
                 let overviews = _.filter(project.docs, { name: `__${project_name}__` })
                 _.each(overviews, (overview) => {
                     if (overview.package_name !== project_name) {


### PR DESCRIPTION
resolves #390

### Description

Similar to https://github.com/dbt-labs/dbt-docs/issues/366, package level overviews from packages imported into a project are not correctly being loaded and rendered in the generated docs sites. This is a regression, and this PR restores the previous behavior.

The fix was confirmed to work by following the instructions in https://github.com/dbt-labs/dbt-docs/issues/390.

🎩 

<img width="315" alt="image" src="https://user-images.githubusercontent.com/44704949/223591082-7c6481f6-698d-495e-b665-0fd05c72862b.png">


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 