### PR TITLE
Revert changes to package-lock.json in #398

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18017,7 +18017,6 @@
     },
     "cytoscape": {
       "version": "git+ssh://git@github.com/dbt-labs/cytoscape.js.git#b8a1192c270de70296a0381bd0bfe26a5ddeada3",
-      "integrity": "sha512-CJDw3nomL5E4OgviTrBhkfLCVaA5bDS5BTuLKY0Qk+/AK75Quue/e5z68RCpwe2G7XMoPjosP0xOrAje2dn6HQ==",
       "dev": true,
       "from": "cytoscape@https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
       "requires": {


### PR DESCRIPTION
My bad! Not sure why this change got added, since `package-lock.json` is pretty clearly in the `.gitignore`