### PR TITLE
Fix for column tests not rendering on quoted columns

### DIFF
--- a/.changes/unreleased/Docs-20230531-115419.yaml
+++ b/.changes/unreleased/Docs-20230531-115419.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Fix for column tests not rendering on quoted columns
+time: 2023-05-31T11:54:19.687363-04:00
+custom:
+  Author: drewbanin
+  Issue: "201"

--- a/src/app/services/compat.js
+++ b/src/app/services/compat.js
@@ -1,0 +1,16 @@
+
+function getQuoteChar(project_metadata) {
+    var backtickDatabases = ['bigquery', 'spark', 'databricks'];
+    var adapter_type = (project_metadata || {}).adapter_type;
+
+    if (backtickDatabases.indexOf(adapter_type) >= 0) {
+        return '`';
+    } else {
+        return '"';
+    }
+}
+
+
+module.exports = {
+    getQuoteChar,
+}

--- a/src/app/services/compat.test.js
+++ b/src/app/services/compat.test.js
@@ -1,0 +1,22 @@
+
+const compat = require("./compat");
+
+const BACKTICK = '`';
+const QUOTE = '"';
+
+
+test("column quoting", () => {
+    expect(compat.getQuoteChar({adapter_type: 'bigquery'})).toStrictEqual(BACKTICK);
+    expect(compat.getQuoteChar({adapter_type: 'spark'})).toStrictEqual(BACKTICK);
+    expect(compat.getQuoteChar({adapter_type: 'databricks'})).toStrictEqual(BACKTICK);
+    expect(compat.getQuoteChar({adapter_type: 'postgres'})).toStrictEqual(QUOTE);
+    expect(compat.getQuoteChar({adapter_type: 'snowflake'})).toStrictEqual(QUOTE);
+    expect(compat.getQuoteChar({adapter_type: 'redshift'})).toStrictEqual(QUOTE);
+    expect(compat.getQuoteChar({adapter_type: 'unknown_db'})).toStrictEqual(QUOTE);
+});
+
+test("column quoting with invalid adapter", () => {
+    expect(compat.getQuoteChar({adapter_type: null})).toStrictEqual(QUOTE);
+    expect(compat.getQuoteChar({})).toStrictEqual(QUOTE);
+    expect(compat.getQuoteChar(null)).toStrictEqual(QUOTE);
+});

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -2,6 +2,7 @@
 const angular = require('angular');
 const $ = require('jquery');
 const _ = require('lodash');
+const { getQuoteChar } = require('./compat');
 
 import merge from 'deepmerge';
 
@@ -13,15 +14,6 @@ function capitalizeType(type) {
         return staticCapitalizations[type];
     }
     return type.charAt(0).toUpperCase() + type.slice(1);
-}
-
-
-function getQuoteChar(project_metadata) {
-    if (project_metadata && project_metadata.adapter_type == 'bigquery') {
-        return '`';
-    } else {
-        return '"';
-    }
 }
 
 

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -228,7 +228,13 @@ angular
                     }
                     var node = project.nodes[model];
                     var column = _.find(node.columns, function(col, col_name) {
-                        return col_name.toLowerCase() == test_column.toLowerCase();
+                        // strip quotes from start and end of test column if present in both locations
+                        // this is necessary to attach a test to a column when `quote: true` is set for a column
+                        let test_column_name = test_column;
+                        if (test_column.startsWith('"') && test_column.endsWith('"')) {
+                            test_column_name = test_column.substring(1, test_column.length-1);
+                        }
+                        return col_name.toLowerCase() == test_column_name.toLowerCase();
                     });
 
                     if (column) {

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -15,6 +15,16 @@ function capitalizeType(type) {
     return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
+
+function getQuoteChar(project_metadata) {
+    if (project_metadata && project_metadata.adapter_type == 'bigquery') {
+        return '`';
+    } else {
+        return '"';
+    }
+}
+
+
 angular
 .module('dbt')
 .factory('project', ['$q', '$http', function($q, $http) {
@@ -227,11 +237,12 @@ angular
                         var model = depends_on[0]
                     }
                     var node = project.nodes[model];
+                    var quote_char = getQuoteChar(project.metadata);
                     var column = _.find(node.columns, function(col, col_name) {
                         // strip quotes from start and end of test column if present in both locations
                         // this is necessary to attach a test to a column when `quote: true` is set for a column
                         let test_column_name = test_column;
-                        if (test_column.startsWith('"') && test_column.endsWith('"')) {
+                        if (test_column.startsWith(quote_char) && test_column.endsWith(quote_char)) {
                             test_column_name = test_column.substring(1, test_column.length-1);
                         }
                         return col_name.toLowerCase() == test_column_name.toLowerCase();


### PR DESCRIPTION
resolves #201

### Description

Quoted columns are rendered with explicit quotes in the manifest.json file. These quotes prevent the dbt-docs site from matching a column name from the manifest (attached to a model) with a test node relevant to that column. Here's an example test node in the manifest for a quoted column:

```yml
        "test.my_new_project.not_null_quoted_ident__TEST_2_COLUMN_.f762812d7c": {
            "test_metadata": {
                "name": "not_null",
                "kwargs": {
                    "column_name": "\"TEST_2_COLUMN\"",
                    "model": "{{ get_where_subquery(ref('quoted_ident')) }}"
                },
                "namespace": null
            },
            "database": "ANALYTICS",
            ...
            "config": {...},
            "compiled_code": "select \"TEST_2_COLUMN\"\nfrom ANALYTICS.dbt_dbanin.quoted_ident\nwhere \"TEST_2_COLUMN\" is null",
            "column_name": "\"TEST_2_COLUMN\"",
            "file_key_name": "models.quoted_ident",
            "attached_node": "model.my_new_project.quoted_ident"
        }
```


It is probably worth exploring a change to the dbt-core implementation in the future. I imagine we could instead leave the column_name field unquoted, but include a boolean `column_is_quoted` flag, or similar. That would make string processing a little bit easier, as well as help us account for different quoting styles across data platforms more readily.

In the meantime, this PR works by stripping quotes from the `column_name` before performing a case-insensitive match across model node + test node.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 