### PR TITLE
We no longer support static sql for metrics in the manifest, so don't try to show an empty code block

### DIFF
--- a/.changes/unreleased/Docs-20230718-192422.yaml
+++ b/.changes/unreleased/Docs-20230718-192422.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Remove static SQL codeblock for metrics
+time: 2023-07-18T19:24:22.155323+02:00
+custom:
+  Author: marcodamore
+  Issue: "436"

--- a/src/app/docs/metric.html
+++ b/src/app/docs/metric.html
@@ -34,7 +34,6 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.metric({'#': 'depends_on'})">Depends On</a></li>
-                <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
     </div>
@@ -67,13 +66,6 @@
                 </div>
             </section>
 
-
-            <section class="section">
-                <div class="section-target" id="code"></div>
-                <div class="section-content">
-                    <code-block versions="versions" default="default_version" language="language"></code-block>
-                </div>
-            </section>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Because we no longer support static sql for metrics in the manifest, we should not show an empty sql codeblock in dbt docs for metrics

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 