### PR TITLE
fix bug dbt docs, having a folder with the same name as a macro breaks dbt docs

### DIFF
--- a/.changes/unreleased/Docs-20230806-191713.yaml
+++ b/.changes/unreleased/Docs-20230806-191713.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Fix crash when folder had the same name as a macro
+time: 2023-08-06T19:17:13.611347561Z
+custom:
+  Author: etnnth
+  Issue: "442"

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -687,11 +687,7 @@ angular
 
             var dirpath = _.initial(path);
 
-            if (node.resource_type == 'macro') {
-                var fname = node.name;
-            } else {
-                var fname = _.last(path);
-            }
+            var fname = `${node.resource_type}.${_.last(path)}.${node.name}`;
 
             if (node.resource_type == 'model' && node.version != null) {
                 var display_name = node.name + "_v" + node.version;
@@ -701,17 +697,18 @@ angular
 
             var cur_dir = tree;
             _.each(dirpath, function(dir) {
-                if (!cur_dir[dir]) {
-                    cur_dir[dir] = {
+                var dname = `dir.${dir}`
+                if (!cur_dir[dname]) {
+                    cur_dir[dname] = {
                         type: 'folder',
                         name: dir,
                         active: is_active,
                         items: {}
                     };
                 } else if (is_active) {
-                    cur_dir[dir].active = true;
+                    cur_dir[dname].active = true;
                 }
-                cur_dir = cur_dir[dir].items;
+                cur_dir = cur_dir[dname].items;
             })
             cur_dir[fname] = {
                 type: 'file',


### PR DESCRIPTION
resolves #442

### Description

Fix bug where the docs site crashed when a macro and a folder had the same name. This was due a a key collision in the tree object that was used to create the project structure. The fix is to change the key to be sure that they cannot be identical.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 