### PR TITLE
Clickable logo to return to overview

### DIFF
--- a/.changes/unreleased/Docs-20230822-111752.yaml
+++ b/.changes/unreleased/Docs-20230822-111752.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Make logo clickable to return to the overview page.
+time: 2023-08-22T11:17:52.419273558+02:00
+custom:
+  Author: jochemvandooren
+  Issue: "446"

--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -19,7 +19,9 @@
                 <div class="app-row app-middle">
                     <div class="app-body">
                         <div class="logo">
-                            <img style="width: 100px; height: 40px" class="logo" ng-src="{{ logo }}" />
+                            <a ui-sref="dbt.overview()">
+                                <img style="width: 100px; height: 40px" class="logo" ng-src="{{ logo }}" />
+                            </a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
resolves #446 

### Description

Make the logo clickable, returning to the overview page.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 