### PR TITLE
Enable easy creation of static index.html pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	npm test
 
 dist: clean
-	DBT_DOCS_ENV=production webpack
+	NODE_OPTIONS=--openssl-legacy-provider DBT_DOCS_ENV=production webpack
 	rm -rf dist/fonts dist/main.js dist/main.js.map
 
 submodule:

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -21,7 +21,14 @@ angular
 .module('dbt')
 .factory('project', ['$q', '$http', function($q, $http) {
 
-    var TARGET_PATH = '';
+    // These tokens will pass-through any webpack process, and
+    // enable replacement of the strings for objects containing
+    // the data for the manifest and catalog (manifest.json and
+    // catalog.json).
+    var INLINE_FILES = {
+      'manifest': 'MANIFEST.JSON INLINE DATA',
+      'catalog': 'CATALOG.JSON INLINE DATA'
+    }
 
     var service = {
         project: {},
@@ -95,6 +102,16 @@ angular
     }
 
     function loadFile(label, path) {
+
+        // If there is an INLINE_FILES that isn't a string (must be JSON data),
+        // use it directly.
+        if (label in INLINE_FILES && typeof INLINE_FILES[label] === "object") {
+          return {
+            label: label,
+            data: INLINE_FILES[label]
+          }
+        }
+
         return $http({
             method: 'GET',
             url: path
@@ -118,8 +135,8 @@ angular
     service.loadProject = function() {
         var cache_bust = "?cb=" + (new Date()).getTime();
         var promises = [
-            loadFile('manifest', TARGET_PATH + "manifest.json" + cache_bust),
-            loadFile('catalog', TARGET_PATH + "catalog.json" + cache_bust),
+            loadFile('manifest', "manifest.json" + cache_bust),
+            loadFile('catalog', "catalog.json" + cache_bust),
         ]
 
         $q.all(promises).then(function(files) {


### PR DESCRIPTION
This uses string tokens for the manifest.json and catalog.json data files that can be used as an alternative -- replacing them with actual objects -- of reading in JSON files.

This is a step to resolving #53. An additional PR will be submitted for dbt-core with the generated index.html from this version.

### Description

Generating a static index.html _after_ a webpack process is not straightforward.

Two strings are used as a unique value in the generated index.html that can be replaced with objects that, when replaced, will use those object values rather than fetching through HTTP for the data.

This will enable an extra step in dbt-core docs generation to generate a static index.html upon request.

Why? See issue #53 for many users over years expressing desire for this. For example, including the static index.html in a ZIP file -- which can be inspected locally -- and hosting it in a blobstorage/GCS/S3 in a way that can be downloaded in isolation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 