### PR TITLE
match new location of index.html

### DIFF
--- a/.github/workflows/generate-docs-for-dbt-core.yml
+++ b/.github/workflows/generate-docs-for-dbt-core.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.set_variables.outputs.index_artifact_name }}
-          path: "core/dbt/include"
+          path: "core/dbt/task/docs"
       
       - name: Download changelog artifact(s)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Description

dbt-core moved the `index.html` from `core/dbt/include` to `core/dbt/task/docs`.  Match the new path.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 