### PR TITLE
Update triage-labels.yml to add conditional

### DIFF
--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   triage_label:
+    if: contains(github.event.issue.labels.*.name, 'awaiting_response')
     uses: dbt-labs/actions/.github/workflows/swap-labels.yml@main
     with:
       add_label: "triage"


### PR DESCRIPTION

### Description

We only want this to run if the current `awaiting_response` label is present.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 