### PR TITLE
Fix #506: Unit tests not rendering

### DIFF
--- a/.changes/unreleased/Docs-20240501-021050.yaml
+++ b/.changes/unreleased/Docs-20240501-021050.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Unit tests not rendering
+time: 2024-05-01T02:10:50.987412+02:00
+custom:
+  Author: aranke
+  Issue: "506"

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -381,8 +381,9 @@ angular
         _.each(_.filter(service.manifest.nodes, function(node) {
             // operation needs to be a graph type so that the parent/child map can be resolved even though we won't be displaying it
             var is_graph_type = _.includes(['model', 'seed', 'source', 'snapshot', 'analysis', 'exposure', 'metric', 'semantic_model', 'operation'], node.resource_type);
-            var is_singular_test = node.resource_type == 'test' && !node.hasOwnProperty('test_metadata');
-            return is_graph_type || is_singular_test;
+            var is_singular_test = node.resource_type === 'test' && !node.hasOwnProperty('test_metadata');
+            var is_unit_test = node.resource_type === 'unit_test';
+            return is_graph_type || is_singular_test || is_unit_test;
         }), function(node) {
             var node_obj = {
                 group: "nodes",


### PR DESCRIPTION
resolves #506 

### Description

Unit test nodes now render in graph (right) and in expanded view (left).

<img width="983" alt="image" src="https://github.com/dbt-labs/dbt-docs/assets/49380716/83263529-85e0-4757-bfbe-b3a5f146c181">


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 