### PR TITLE
Use github: specifier instead of URL for cytoscape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "base64-inline-loader": "^1.1.1",
         "bootstrap": "3",
         "css-loader": "^1.0.0",
-        "cytoscape": "https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
+        "cytoscape": "github:dbt-labs/cytoscape.js#feature/cubic-bezier-edges",
         "cytoscape-context-menus": "3.0.5",
         "cytoscape-dagre": "^2.2.1",
         "cytoscape-expand-collapse": "^3.1.1",
@@ -6065,9 +6065,7 @@
     "node_modules/cytoscape": {
       "version": "3.20.3",
       "resolved": "git+ssh://git@github.com/dbt-labs/cytoscape.js.git#b8a1192c270de70296a0381bd0bfe26a5ddeada3",
-      "integrity": "sha512-CJDw3nomL5E4OgviTrBhkfLCVaA5bDS5BTuLKY0Qk+/AK75Quue/e5z68RCpwe2G7XMoPjosP0xOrAje2dn6HQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"
@@ -19340,9 +19338,8 @@
     },
     "cytoscape": {
       "version": "git+ssh://git@github.com/dbt-labs/cytoscape.js.git#b8a1192c270de70296a0381bd0bfe26a5ddeada3",
-      "integrity": "sha512-CJDw3nomL5E4OgviTrBhkfLCVaA5bDS5BTuLKY0Qk+/AK75Quue/e5z68RCpwe2G7XMoPjosP0xOrAje2dn6HQ==",
       "dev": true,
-      "from": "cytoscape@https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
+      "from": "cytoscape@github:dbt-labs/cytoscape.js#feature/cubic-bezier-edges",
       "requires": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "base64-inline-loader": "^1.1.1",
     "bootstrap": "3",
     "css-loader": "^1.0.0",
-    "cytoscape": "https://github.com/dbt-labs/cytoscape.js.git#feature/cubic-bezier-edges",
+    "cytoscape": "github:dbt-labs/cytoscape.js#feature/cubic-bezier-edges",
     "cytoscape-context-menus": "3.0.5",
     "cytoscape-dagre": "^2.2.1",
     "cytoscape-expand-collapse": "^3.1.1",


### PR DESCRIPTION
### Description

Bypass SSH cloning issues by using the native GitHub format, avoid this error in workflow to update docs in `dbt-core`:

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/dbt-labs/cytoscape.js.git
npm ERR! 
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR! 
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR! 
npm ERR! exited with error code: 128
```

https://github.com/dbt-labs/dbt-docs/actions/runs/9501441754/job/26187282464#step:7:537

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 