### PR TITLE
 Show first order parents/children in lineage graph

### DIFF
--- a/.changes/unreleased/Docs-20240619-121151.yaml
+++ b/.changes/unreleased/Docs-20240619-121151.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: ' Show first order parents/children in lineage graph'
+time: 2024-06-19T12:11:51.633757646+02:00
+custom:
+    Author: jvandooren
+    Issue: "516"

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -497,6 +497,7 @@ angular
 
         if (node_name) {
             selected_spec.include = "+" + node_name + "+";
+            selected_spec.hops = 1;
             selected_spec.exclude = "";
         } else {
             selected_spec.include = "";

--- a/src/app/services/node_selection_service.js
+++ b/src/app/services/node_selection_service.js
@@ -56,19 +56,19 @@ angular
     service.resetSelection = function(node) {
         var include_selection;
         if (node && _.includes(['model', 'seed', 'snapshot'], node.resource_type)) {
-            include_selection = '+' + node.name + '+';
+            include_selection = '1+' + node.name + '+1';
         } else if (node && node.resource_type == 'source') {
-            include_selection = '+source:' + node.source_name + "." + node.name + '+';
+            include_selection = '1+source:' + node.source_name + "." + node.name + '+1';
         } else if (node && node.resource_type == 'exposure') {
-            include_selection = '+exposure:' + node.name;
+            include_selection = '1+exposure:' + node.name;
         } else if (node && node.resource_type == 'metric') {
-            include_selection = '+metric:' + node.name;
+            include_selection = '1+metric:' + node.name;
         } else if (node && node.resource_type == 'semantic_model') {
-            include_selection = '+semantic_model:' + node.name;
+            include_selection = '1+semantic_model:' + node.name;
         } else if (node && node.resource_type == 'saved_query') {
-            include_selection = '+saved_query:' + node.name;
+            include_selection = '1+saved_query:' + node.name;
         } else if (node && _.includes(['analysis', 'test', 'unit_test'], node.resource_type)) {
-            include_selection = '+' + node.name;
+            include_selection = '1+' + node.name;
         } else {
             include_selection = "";
         }


### PR DESCRIPTION
resolves #516 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Instead of showing the full lineage, show the first order of parents and children when opening the full screen lineage graph.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 