### PR TITLE
Feature: Display external tables details

### DIFF
--- a/.changes/unreleased/Docs-20260106-135315.yaml
+++ b/.changes/unreleased/Docs-20260106-135315.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Add external table configuration details to source table_details
+time: 2026-01-06T13:53:15.813385-05:00
+custom:
+    Author: portalhacker
+    Issue: "572"

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -39,6 +39,16 @@
                             </dl>
                         </div>
                     </div>
+                    <div class="detail-group" ng-if="hasData(external)">
+                        <div class="detail-body">
+                            <dl class="detail"
+                                ng-repeat="item in external">
+                                <dt class="detail-label">{{ item.name }}</dt>
+                                <dd class="detail-value" ng-if="!item.isUrl">{{ item.value }}</dd>
+                                <dd class="detail-value" ng-if="item.isUrl"><a ng-href="{{ item.value }}" target="_blank">{{ item.value }}</a></dd>
+                            </dl>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -19,6 +19,7 @@ angular
 
             scope.details = [];
             scope.extended = [];
+            scope.external = [];
             scope.exclude = scope.exclude || [];
             scope.meta = null;
             scope._show_expanded = false;
@@ -181,6 +182,50 @@ angular
                 return mapped;
             }
 
+            function getExternalTablesInfo(external) {
+                if (!external || _.isEmpty(external)) {
+                    return [];
+                }
+
+                var result = [];
+                _.each(external, function(value, key) {
+                    if (value === null || value === undefined) {
+                        return;
+                    }
+
+                    if (key === 'options' && typeof value === 'object') {
+                        // Expand options into separate rows
+                        _.each(value, function(optValue, optKey) {
+                            if (optValue !== null && optValue !== undefined) {
+                                result.push({
+                                    name: 'Option: ' + optKey,
+                                    value: String(optValue),
+                                    isUrl: false
+                                });
+                            }
+                        });
+                    } else if (typeof value === 'object') {
+                        // For other objects, stringify them
+                        var stringValue = JSON.stringify(value);
+                        if (stringValue !== '{}' && stringValue !== '[]') {
+                            result.push({
+                                name: key,
+                                value: stringValue,
+                                isUrl: false
+                            });
+                        }
+                    } else {
+                        result.push({
+                            name: key,
+                            value: String(value),
+                            isUrl: key === 'location' && typeof value === 'string' && value.match(/^https?:\/\//)
+                        });
+                    }
+                });
+
+                return result;
+            }
+
             scope.$watch("model", function(nv, ov) {
                 var get_type = _.property(['metadata', 'type'])
                 var rel_type = get_type(nv);
@@ -190,6 +235,7 @@ angular
                 
                 scope.details = getBaseStats(nv);
                 scope.extended = getExtendedStats(nv.stats);
+                scope.external = getExternalTablesInfo(nv.external);
 
                 if (scope.extras) {
                     var extrasToAdd = _.filter(scope.extras, function(extra) {


### PR DESCRIPTION
resolves #572

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

<br>

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Add an optional new container to the `table-details` template with a clickable link.

Then hydrate it based on the keys and values found under the source `external` key for [dbt-labs/dbt_external_tables](https://github.com/dbt-labs/dbt-external-tables).

This was tested for 2 types of external tables with BigQuery:
- Google Cloud Storage
- Google Sheets

It should work in every database and external table types.

Here is an example of the output:

<img width="1340" height="366" alt="screenshot_n0J69ggl_20260106T142850" src="https://github.com/user-attachments/assets/e550c58e-d342-4f0a-bab2-923aa4d5a85d" />


<br>

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 