### PR TITLE
Add anchor links for individual columns

### DIFF
--- a/.changes/unreleased/Docs-20260227-120000.yaml
+++ b/.changes/unreleased/Docs-20260227-120000.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: Add anchor links for individual columns in model pages
+time: 2026-02-27T12:00:00.000000+09:00
+custom:
+    Author: xinkent
+    Issue: "186"

--- a/src/app/components/column_details/column_details.html
+++ b/src/app/components/column_details/column_details.html
@@ -1,3 +1,18 @@
+<style>
+.column-row .column-anchor {
+    visibility: hidden;
+    color: #adb5bd;
+    text-decoration: none;
+    margin-left: 4px;
+    font-size: 12px;
+}
+.column-row:hover .column-anchor {
+    visibility: visible;
+}
+.column-row .column-anchor:hover {
+    color: #0078d4;
+}
+</style>
 <div class="panel">
     <div class="panel-body">
         <div ng-if="_.isEmpty(model.columns)">
@@ -21,12 +36,14 @@
                     <tr
                         ng-repeat-start="column in get_columns(model) track by column.index"
                         ng-click="toggle_column_expanded(column)"
+                        id="column-{{ column.name }}"
                         class="column-row"
                         ng-class="{'column-row-selected': column.expanded}"
                         ng-style="{cursor: has_more_info(column) ? 'pointer' : 'auto'}">
                         <td>
                             <div>
                                 <span class='text-dark'>{{ get_col_name(column.name) }}</span>
+                                <a class="column-anchor" ng-click="column_anchor(column, $event)" title="Link to this column">#</a>
                             </div>
                         </td>
                         <td>

--- a/src/app/components/column_details/column_details.js
+++ b/src/app/components/column_details/column_details.js
@@ -6,7 +6,7 @@ const _ = require('underscore');
 
 angular
 .module('dbt')
-.directive('columnDetails', ['project', function(projectService) {
+.directive('columnDetails', ['project', '$location', '$anchorScroll', '$timeout', function(projectService, $location, $anchorScroll, $timeout) {
     return {
         scope: {
             model: '=',
@@ -14,11 +14,35 @@ angular
         templateUrl: template,
         link: function(scope) {
 
+            scope.column_anchor = function(column, $event) {
+                $event.stopPropagation();
+                $location.hash('column-' + column.name);
+                if (scope.has_more_info(column)) {
+                    column.expanded = true;
+                }
+            }
+
+            scope.$watch('model.columns', function(columns) {
+                if (!columns || _.isEmpty(columns)) return;
+                var hash = $location.hash();
+                if (!hash || hash.indexOf('column-') !== 0) return;
+                var col_name = hash.substring('column-'.length);
+                var target = _.find(columns, function(col) {
+                    return col.name === col_name || col.name.toLowerCase() === col_name.toLowerCase();
+                });
+                if (target && scope.has_more_info(target)) {
+                    target.expanded = true;
+                }
+                $timeout(function() {
+                    $anchorScroll();
+                }, 0);
+            });
+
             scope.has_test = function(col, test_name) {
                 var test_types = _.pluck(col.tests, 'short');
                 return test_types.indexOf(test_name) != -1;
             }
-            
+
             scope.has_constraint = function(col, constraint_name) {
                 if (!col.hasOwnProperty('constraints')) {
                     return false;
@@ -67,4 +91,3 @@ angular
         }
     }
 }]);
-

--- a/src/app/components/column_details/column_details.js
+++ b/src/app/components/column_details/column_details.js
@@ -6,7 +6,7 @@ const _ = require('underscore');
 
 angular
 .module('dbt')
-.directive('columnDetails', ['project', '$location', '$anchorScroll', '$timeout', function(projectService, $location, $anchorScroll, $timeout) {
+.directive('columnDetails', ['project', '$location', function(projectService, $location) {
     return {
         scope: {
             model: '=',
@@ -33,9 +33,17 @@ angular
                 if (target && scope.has_more_info(target)) {
                     target.expanded = true;
                 }
-                $timeout(function() {
-                    $anchorScroll();
-                }, 0);
+                // Adjust scroll after model controller's $anchorScroll() completes
+                // Use native setTimeout to avoid triggering an Angular digest cycle
+                setTimeout(function() {
+                    var el = document.getElementById(hash);
+                    if (!el) return;
+                    var appScroll = el.closest('.app-scroll');
+                    var stickyHeader = appScroll && appScroll.querySelector('.app-sticky');
+                    if (appScroll && stickyHeader) {
+                        appScroll.scrollTop -= stickyHeader.offsetHeight;
+                    }
+                }, 200);
             });
 
             scope.has_test = function(col, test_name) {


### PR DESCRIPTION
resolves #186

### Description

Add anchor links for individual columns in the column details table, as requested in [dbt-labs/dbt-docs#186](https://github.com/dbt-labs/dbt-docs/issues/186).

Each column row now has an HTML `id` attribute (`column-<name>`) and a clickable `#` link that appears on hover. Clicking the link updates the URL hash (e.g. `#!/model/model.my_model#column-customer_id`) so it can be shared. When navigating to a URL with a `#column-<name>` fragment, the matching column is automatically expanded and scrolled into view via `$anchorScroll`.

This applies to all pages using the `column-details` directive: model, source, seed, and snapshot.

**Changes:**
- `src/app/components/column_details/column_details.html` — Added `id` attribute to column rows, anchor link element, and hover CSS
- `src/app/components/column_details/column_details.js` — Added `column_anchor()` click handler, `$watch` on `model.columns` for auto-expand and scroll on page load

<img width="763" height="403" alt="image" src="https://github.com/user-attachments/assets/83a0305e-48c2-4f48-99d0-de05b170f78a" />



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)