### PR TITLE
feat: add Config tab to all node resource detail pages

### DIFF
--- a/src/app/components/config_details/config_details.css
+++ b/src/app/components/config_details/config_details.css
@@ -1,0 +1,54 @@
+.config-root {
+    margin: 0;
+}
+
+.config-entry {
+    padding: 4px 0;
+}
+
+.config-entry-scalar {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: baseline;
+}
+
+.config-entry-scalar > .detail-label {
+    flex: 0 0 160px;
+    text-transform: uppercase;
+}
+
+.config-entry-scalar > .detail-value {
+    flex: 1 1 auto;
+    min-width: 0;
+    word-break: break-word;
+}
+
+.config-entry-nested > .detail-label {
+    text-transform: uppercase;
+    margin-bottom: 2px;
+}
+
+.config-nested {
+    margin: 0;
+    padding-left: 20px;
+    border-left: 1px solid #e0e0e0;
+}
+
+.config-nested .config-entry {
+    padding: 2px 0;
+}
+
+.config-nested .config-entry-scalar > .detail-label {
+    flex: 0 0 140px;
+}
+
+.config-entry code {
+    margin-right: 4px;
+}
+
+.config-array-item {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: baseline;
+    padding: 2px 0;
+}

--- a/src/app/components/config_details/config_details.html
+++ b/src/app/components/config_details/config_details.html
@@ -1,0 +1,44 @@
+<div class="section-content">
+    <h6>Config</h6>
+    <div class="panel">
+        <div class="panel-body">
+            <script type="text/ng-template" id="config-entry.html">
+                <div ng-if="entry.type === 'scalar'" class="config-entry config-entry-scalar">
+                    <dt class="detail-label" ng-bind="entry.key"></dt>
+                    <dd class="detail-value" ng-bind="entry.value"></dd>
+                </div>
+                <div ng-if="entry.type === 'array'" class="config-entry config-entry-scalar">
+                    <dt class="detail-label" ng-bind="entry.key"></dt>
+                    <dd class="detail-value">
+                        <span ng-if="entry.isSimpleArray">
+                            <code ng-repeat="item in entry.value" ng-bind="item"></code>
+                        </span>
+                        <dl ng-if="!entry.isSimpleArray" class="config-nested">
+                            <div ng-repeat="child in entry.value" class="config-array-item">
+                                <dt class="detail-label">[<span ng-bind="$index"></span>]</dt>
+                                <dd ng-if="child.type === 'scalar'" class="detail-value" ng-bind="child.value"></dd>
+                                <dd ng-if="child.type === 'object'" class="detail-value">
+                                    <dl class="config-nested">
+                                        <div ng-repeat="nestedEntry in child.entries" ng-init="entry = nestedEntry" ng-include="'config-entry.html'"></div>
+                                    </dl>
+                                </dd>
+                            </div>
+                        </dl>
+                    </dd>
+                </div>
+                <div ng-if="entry.type === 'object'" class="config-entry config-entry-nested">
+                    <dt class="detail-label" ng-bind="entry.key"></dt>
+                    <dd class="detail-value">
+                        <dl class="config-nested">
+                            <div ng-repeat="nestedEntry in entry.entries" ng-init="entry = nestedEntry" ng-include="'config-entry.html'"></div>
+                        </dl>
+                    </dd>
+                </div>
+            </script>
+            <dl class="config-root">
+                <div ng-repeat="entry in entries" ng-include="'config-entry.html'"></div>
+            </dl>
+            <div ng-if="entries.length === 0" class="text-muted">No config available</div>
+        </div>
+    </div>
+</div>

--- a/src/app/components/config_details/config_details.js
+++ b/src/app/components/config_details/config_details.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const template = require('./config_details.html');
+require("./config_details.css");
+
+const _ = require('underscore');
+const { toEntries } = require('./config_utils');
+
+angular
+.module('dbt')
+.directive('configDetails', [function() {
+    return {
+        scope: {
+            config: '=',
+        },
+        templateUrl: template,
+        link: function(scope) {
+
+            scope.entries = [];
+
+            scope.$watch("config", function(nv) {
+                if (nv && _.isObject(nv)) {
+                    scope.entries = toEntries(nv);
+                } else {
+                    scope.entries = [];
+                }
+            });
+        }
+    }
+}]);

--- a/src/app/components/config_details/config_utils.js
+++ b/src/app/components/config_details/config_utils.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var _ = require('underscore');
+
+var PRIORITY_KEYS = ['materialized', 'enabled', 'schema', 'database', 'alias', 'tags', 'group'];
+
+function isEmptyValue(value) {
+    if (value === null || value === undefined) return true;
+    if (_.isArray(value) && value.length === 0) return true;
+    if (_.isObject(value) && !_.isArray(value) && _.isEmpty(value)) return true;
+    return false;
+}
+
+function isSimpleArray(arr) {
+    return _.every(arr, function(item) {
+        return !_.isObject(item);
+    });
+}
+
+function sortKeys(keys) {
+    return keys.sort(function(a, b) {
+        var aIdx = PRIORITY_KEYS.indexOf(a);
+        var bIdx = PRIORITY_KEYS.indexOf(b);
+        if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
+        if (aIdx !== -1) return -1;
+        if (bIdx !== -1) return 1;
+        return a.localeCompare(b);
+    });
+}
+
+function toEntry(key, value) {
+    if (_.isArray(value)) {
+        if (isSimpleArray(value)) {
+            return { key: key, value: value, type: 'array', isSimpleArray: true };
+        }
+        var children = _.map(value, function(item) {
+            if (_.isObject(item)) {
+                return { type: 'object', entries: toEntries(item) };
+            }
+            return { type: 'scalar', value: item };
+        });
+        return { key: key, value: children, type: 'array', isSimpleArray: false };
+    }
+    if (_.isObject(value)) {
+        return { key: key, entries: toEntries(value), type: 'object' };
+    }
+    return { key: key, value: value, type: 'scalar' };
+}
+
+function toEntries(obj) {
+    var keys = sortKeys(_.keys(obj));
+    return _.chain(keys)
+        .filter(function(k) { return !isEmptyValue(obj[k]); })
+        .map(function(k) { return toEntry(k, obj[k]); })
+        .value();
+}
+
+module.exports = {
+    isEmptyValue: isEmptyValue,
+    isSimpleArray: isSimpleArray,
+    toEntry: toEntry,
+    toEntries: toEntries
+};

--- a/src/app/components/config_details/config_utils.test.js
+++ b/src/app/components/config_details/config_utils.test.js
@@ -1,0 +1,169 @@
+const { isEmptyValue, isSimpleArray, toEntry, toEntries } = require('./config_utils');
+
+describe('config_utils', function() {
+
+    describe('isEmptyValue', function() {
+        it('returns true for null', function() {
+            expect(isEmptyValue(null)).toBe(true);
+        });
+
+        it('returns true for undefined', function() {
+            expect(isEmptyValue(undefined)).toBe(true);
+        });
+
+        it('returns true for empty array', function() {
+            expect(isEmptyValue([])).toBe(true);
+        });
+
+        it('returns true for empty object', function() {
+            expect(isEmptyValue({})).toBe(true);
+        });
+
+        it('returns false for non-empty string', function() {
+            expect(isEmptyValue('hello')).toBe(false);
+        });
+
+        it('returns false for zero', function() {
+            expect(isEmptyValue(0)).toBe(false);
+        });
+
+        it('returns false for false', function() {
+            expect(isEmptyValue(false)).toBe(false);
+        });
+
+        it('returns false for non-empty array', function() {
+            expect(isEmptyValue([1])).toBe(false);
+        });
+
+        it('returns false for non-empty object', function() {
+            expect(isEmptyValue({ a: 1 })).toBe(false);
+        });
+    });
+
+    describe('isSimpleArray', function() {
+        it('returns true for array of strings', function() {
+            expect(isSimpleArray(['a', 'b'])).toBe(true);
+        });
+
+        it('returns true for array of numbers', function() {
+            expect(isSimpleArray([1, 2])).toBe(true);
+        });
+
+        it('returns true for mixed primitives', function() {
+            expect(isSimpleArray(['a', 1, true])).toBe(true);
+        });
+
+        it('returns false for array containing objects', function() {
+            expect(isSimpleArray([{ a: 1 }])).toBe(false);
+        });
+
+        it('returns true for empty array', function() {
+            expect(isSimpleArray([])).toBe(true);
+        });
+    });
+
+    describe('toEntry', function() {
+        it('creates scalar entry for string', function() {
+            expect(toEntry('key', 'value')).toEqual({
+                key: 'key', value: 'value', type: 'scalar'
+            });
+        });
+
+        it('creates scalar entry for number', function() {
+            expect(toEntry('count', 42)).toEqual({
+                key: 'count', value: 42, type: 'scalar'
+            });
+        });
+
+        it('creates scalar entry for boolean', function() {
+            expect(toEntry('enabled', true)).toEqual({
+                key: 'enabled', value: true, type: 'scalar'
+            });
+
+            expect(toEntry('enabled', false)).toEqual({
+                key: 'enabled', value: false, type: 'scalar'
+            });
+        });
+
+        it('creates simple array entry', function() {
+            var result = toEntry('tags', ['a', 'b']);
+            expect(result.type).toBe('array');
+            expect(result.isSimpleArray).toBe(true);
+            expect(result.value).toEqual(['a', 'b']);
+        });
+
+        it('creates complex array entry', function() {
+            var result = toEntry('items', [{ name: 'x' }]);
+            expect(result.type).toBe('array');
+            expect(result.isSimpleArray).toBe(false);
+            expect(result.value[0].type).toBe('object');
+        });
+
+        it('creates object entry', function() {
+            var result = toEntry('contract', { enforced: true });
+            expect(result.type).toBe('object');
+            expect(result.entries).toEqual([
+                { key: 'enforced', value: true, type: 'scalar' }
+            ]);
+        });
+    });
+
+    describe('toEntries', function() {
+        it('filters out null values', function() {
+            var result = toEntries({ a: 'x', b: null, c: 'y' });
+            expect(result.map(function(e) { return e.key; })).toEqual(['a', 'c']);
+        });
+
+        it('filters out empty objects', function() {
+            var result = toEntries({ a: 'x', b: {} });
+            expect(result.map(function(e) { return e.key; })).toEqual(['a']);
+        });
+
+        it('filters out empty arrays', function() {
+            var result = toEntries({ a: 'x', b: [] });
+            expect(result.map(function(e) { return e.key; })).toEqual(['a']);
+        });
+
+        it('sorts priority keys first', function() {
+            var result = toEntries({
+                on_schema_change: 'ignore',
+                materialized: 'view',
+                enabled: true,
+                alias: 'foo'
+            });
+            var keys = result.map(function(e) { return e.key; });
+            expect(keys).toEqual(['materialized', 'enabled', 'alias', 'on_schema_change']);
+        });
+
+        it('sorts non-priority keys alphabetically', function() {
+            var result = toEntries({ zebra: 1, apple: 2 });
+            var keys = result.map(function(e) { return e.key; });
+            expect(keys).toEqual(['apple', 'zebra']);
+        });
+
+        it('handles nested objects', function() {
+            var result = toEntries({
+                contract: { enforced: false },
+                docs: { show: true, node_color: 'crimson' }
+            });
+            expect(result.length).toBe(2);
+            expect(result[0].type).toBe('object');
+            expect(result[0].entries[0].key).toBe('enforced');
+            expect(result[1].entries.map(function(e) { return e.key; })).toEqual(['node_color', 'show']);
+        });
+
+        it('returns empty array for empty object', function() {
+            expect(toEntries({})).toEqual([]);
+        });
+
+        it('preserves boolean false as value', function() {
+            var result = toEntries({ enforced: false });
+            expect(result[0].value).toBe(false);
+        });
+
+        it('preserves zero as value', function() {
+            var result = toEntries({ count: 0 });
+            expect(result[0].value).toBe(0);
+        });
+    });
+});

--- a/src/app/components/index.js
+++ b/src/app/components/index.js
@@ -9,3 +9,4 @@ require('./column_details/column_details.js');
 require('./code_block/code_block.js');
 require('./macro_arguments/');
 require('./references/');
+require('./config_details/config_details.js');

--- a/src/app/docs/analysis.html
+++ b/src/app/docs/analysis.html
@@ -35,6 +35,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.analysis({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.analysis({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.analysis({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.analysis({'#': 'sql'})">SQL</a></li>
             </ul>
         </div>
@@ -61,6 +62,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/exposure.html
+++ b/src/app/docs/exposure.html
@@ -37,6 +37,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.exposure({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.exposure({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active' ng-show="exposure.config"><a ui-sref="dbt.exposure({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.exposure({'#': 'depends_on'})">Depends On</a></li>
             </ul>
         </div>
@@ -60,6 +61,11 @@
                         </div>
                     </div>
                 </div>
+            </section>
+
+            <section class="section" ng-show="exposure.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="exposure.config"></config-details>
             </section>
 
             <section class="section" ng-show = "parentsLength != 0">

--- a/src/app/docs/function.html
+++ b/src/app/docs/function.html
@@ -33,6 +33,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.function({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.function({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.function({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.function({'#': 'code'})">Code</a></li>
                 <li ui-sref-active='active' ng-show="referencesLength != 0"><a ui-sref="dbt.function({'#': 'referenced_by'})">Referenced By</a></li>
                 <li ui-sref-active='active' ng-show="parentsLength != 0"><a ui-sref="dbt.function({'#': 'depends_on'})">Depends On</a></li>
@@ -58,6 +59,11 @@
                         </div>
                     </div>
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/metric.html
+++ b/src/app/docs/metric.html
@@ -33,6 +33,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.metric({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active' ng-show="metric.config"><a ui-sref="dbt.metric({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.metric({'#': 'depends_on'})">Depends On</a></li>
             </ul>
         </div>
@@ -56,6 +57,11 @@
                         </div>
                     </div>
                 </div>
+            </section>
+
+            <section class="section" ng-show="metric.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="metric.config"></config-details>
             </section>
 
             <section class="section" ng-show = "parentsLength != 0">

--- a/src/app/docs/model.html
+++ b/src/app/docs/model.html
@@ -38,6 +38,7 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'columns'})">Columns</a></li>
                 <li ui-sref-active='active' ng-show = "referencesLength != 0"><a ui-sref="dbt.model({'#': 'referenced_by'})">Referenced By</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.model({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.model({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'code'})">Code</a></li>
             </ul>
         </div>
@@ -84,6 +85,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/operation.html
+++ b/src/app/docs/operation.html
@@ -29,6 +29,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.operation({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.operation({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.operation({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.operation({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
@@ -54,6 +55,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/saved_query.html
+++ b/src/app/docs/saved_query.html
@@ -33,6 +33,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.saved_query({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.saved_query({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active' ng-show="saved_query.config"><a ui-sref="dbt.saved_query({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.saved_query({'#': 'depends_on'})">Depends On</a></li>
             </ul>
         </div>
@@ -82,6 +83,11 @@
                     </div>
                 </div>
             </div>
+        </section>
+
+        <section class="section" ng-show="saved_query.config">
+            <div class="section-target" id="config"></div>
+            <config-details config="saved_query.config"></config-details>
         </section>
 
             <section class="section" ng-show = "parentsLength != 0">

--- a/src/app/docs/seed.html
+++ b/src/app/docs/seed.html
@@ -38,6 +38,7 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.seed({'#': 'columns'})">Columns</a></li>
                 <li ui-sref-active='active' ng-show = "referencesLength != 0"><a ui-sref="dbt.seed({'#': 'referenced_by'})">Referenced By</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.seed({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.seed({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.seed({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
@@ -83,6 +84,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/semantic_model.html
+++ b/src/app/docs/semantic_model.html
@@ -33,6 +33,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.semantic_model({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.semantic_model({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active' ng-show="semantic_model.config"><a ui-sref="dbt.semantic_model({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.semantic_model({'#': 'depends_on'})">Depends On</a></li>
             </ul>
         </div>
@@ -82,6 +83,11 @@
                     </div>
                 </div>
             </div>
+        </section>
+
+        <section class="section" ng-show="semantic_model.config">
+            <div class="section-target" id="config"></div>
+            <config-details config="semantic_model.config"></config-details>
         </section>
 
             <section class="section" ng-show = "parentsLength != 0">

--- a/src/app/docs/snapshot.html
+++ b/src/app/docs/snapshot.html
@@ -38,6 +38,7 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.snapshot({'#': 'columns'})">Columns</a></li>
                 <li ui-sref-active='active' ng-show = "referencesLength != 0"><a ui-sref="dbt.snapshot({'#': 'referenced_by'})">Referenced By</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.snapshot({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.snapshot({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.snapshot({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
@@ -84,6 +85,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/source.html
+++ b/src/app/docs/source.html
@@ -31,6 +31,7 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.source({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.source({'#': 'columns'})">Columns</a></li>
                 <li ui-sref-active='active' ng-show = "referencesLength != 0"><a ui-sref="dbt.source({'#': 'referenced_by'})">Referenced By</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.source({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.source({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
@@ -68,6 +69,11 @@
                     <h6>Referenced By</h6>
                     <reference-list references="references" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/test.html
+++ b/src/app/docs/test.html
@@ -29,6 +29,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.test({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.test({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.test({'#': 'config'})">Config</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.test({'#': 'code'})">SQL</a></li>
             </ul>
         </div>
@@ -54,6 +55,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
             <section class="section">

--- a/src/app/docs/unit_test.html
+++ b/src/app/docs/unit_test.html
@@ -29,6 +29,7 @@
             <ul class="nav nav-tabs">
                 <li ui-sref-active='active'><a ui-sref="dbt.unit_test({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.unit_test({'#': 'depends_on'})">Depends On</a></li>
+                <li ui-sref-active='active' ng-show="model.config"><a ui-sref="dbt.unit_test({'#': 'config'})">Config</a></li>
             </ul>
         </div>
     </div>
@@ -53,6 +54,11 @@
                     <h6>Depends On</h6>
                     <reference-list references="parents" node="model" />
                 </div>
+            </section>
+
+            <section class="section" ng-show="model.config">
+                <div class="section-target" id="config"></div>
+                <config-details config="model.config"></config-details>
             </section>
 
         </div>


### PR DESCRIPTION
resolves #581

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

Thanks for maintaining dbt-docs! I'd appreciate any feedback on this change.

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Currently there's no way to see a resource's dbt config directly in the docs UI. When working with engines like Athena, knowing partition and format settings (`partitioned_by`, `file_format`, etc.) is essential to writing efficient queries, but right now you have to go back to the YAML source to find them.

This PR adds a "Config" tab to all node-type detail pages that shows the full config in a structured, nested format. The tab only appears when config data exists, so macro pages are unaffected. Nested values like `contract` and `docs` render hierarchically, and null/empty entries are filtered out.

I extracted the data transformation logic into a testable `config_utils.js` module with 29 unit tests. All existing tests continue to pass. Tested locally against the jaffle_shop sample data.

<img width="1188" height="710" alt="Screenshot 2026-04-09 at 22 05 04" src="https://github.com/user-attachments/assets/e7e6b363-fc2d-4a4f-98e5-6ad6c5c34546" />

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 