### PR TITLE
feat: display `event_time` in model details panel

### DIFF
--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -115,6 +115,10 @@ angular
                     ? model.config.contract.enforced
                     : false;
 
+                const event_time = model.hasOwnProperty('config') && model.config.event_time
+                    ? model.config.event_time
+                    : undefined;
+
                 var stats = [
                     {
                         name: "Owner",
@@ -147,6 +151,10 @@ angular
                     {
                         name: "Contract",
                         value: config_enforced ? "Enforced" : "Not Enforced"
+                    },
+                    {
+                        name: "Event Time",
+                        value: event_time
                     },
                 ]
 


### PR DESCRIPTION
## Summary

Display the `event_time` configuration in the model details panel of the dbt docs UI.

Closes #583
Ref: [dbt-labs/dbt-core#12800](https://github.com/dbt-labs/dbt-core/issues/12800)

## Problem

Developers working with microbatch models need to verify that `event_time` is configured on a model and its parents. Currently, they have to manually check both the YAML config and the code — the docs UI doesn't surface this information even though it's already present in the manifest at `node.config.event_time`.

## Solution

Add an "Event Time" row to the model details panel in `table_details.js`, following the same pattern as other config-derived properties (Owner, Language, Contract, etc.).

The change:
1. Reads `event_time` from `model.config.event_time`
2. Adds it to the `getBaseStats()` detail list
3. Only displays it when configured (the existing `_.filter` removes entries with `undefined` values)

### Code change (3 lines added)

```js
// In getBaseStats():
const event_time = model.hasOwnProperty('config') && model.config.event_time
    ? model.config.event_time
    : undefined;

// In the stats array:
{
    name: "Event Time",
    value: event_time
},
```

## How it looks

When `event_time` is configured on a model, the details panel will show:
```
Event Time    created_at
```

When `event_time` is not configured, the row is hidden (same behavior as Version, Access, etc.).

## Checks

- [x] Minimal change — only `table_details.js` modified
- [x] Follows existing patterns for config-derived details
- [x] No display when `event_time` is not configured (graceful degradation)
- [x] CLA signed